### PR TITLE
Reject new updates detected with Cruft

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/Ouranosinc/cookiecutter-pypackage.git",
-  "commit": "66708e5e15f00caaaaf1748bf0a7e041bc5c6243",
+  "commit": "273d570f627b0ac0fb07c2457f0072e492bff6d7",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -21,9 +21,9 @@
       "create_author_file": "y",
       "open_source_license": "Apache Software License 2.0",
       "generated_with_cruft": "n",
-      "__gh_slug": "https://github.com/glamod/marine_qc",
+      "__gh_slug": "https://github.com/ludwiglierhammer/Marine-Quality-Control",
       "_template": "https://github.com/Ouranosinc/cookiecutter-pypackage.git",
-      "_commit": "66708e5e15f00caaaaf1748bf0a7e041bc5c6243"
+      "_commit": "273d570f627b0ac0fb07c2457f0072e492bff6d7"
     }
   },
   "directory": null


### PR DESCRIPTION
This is an autogenerated PR. Use this to reject the changes in this repository.
[Cruft](https://cruft.github.io/cruft/) has detected updates from the Cookiecutter repository.