### PR TITLE
Reject new updates detected with Cruft

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/Ouranosinc/cookiecutter-pypackage.git",
-  "commit": "66708e5e15f00caaaaf1748bf0a7e041bc5c6243",
+  "commit": "bf9375753c0b11184f843aadae91eb8581b804ad",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -21,9 +21,9 @@
       "create_author_file": "y",
       "open_source_license": "Apache Software License 2.0",
       "generated_with_cruft": "n",
-      "__gh_slug": "https://github.com/glamod/marine_qc",
+      "__gh_slug": "https://github.com/ludwiglierhammer/Marine-Quality-Control",
       "_template": "https://github.com/Ouranosinc/cookiecutter-pypackage.git",
-      "_commit": "66708e5e15f00caaaaf1748bf0a7e041bc5c6243"
+      "_commit": "bf9375753c0b11184f843aadae91eb8581b804ad"
     }
   },
   "directory": null


### PR DESCRIPTION
This is an autogenerated PR. Use this to reject the changes in this repository.
[Cruft](https://cruft.github.io/cruft/) has detected updates from the Cookiecutter repository.