### PR TITLE
No hard coded years in `do_date_check`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+0.3.2 (unreleased)
+------------------
+Contributors to this version: Ludwig Lierhammer (:user:`ludwiglierhammer`)
+
+New features and environments
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* `do_date_check` now supports flexible input parameters `year_init` and `year_end` that define valid year range (:pull:`184`)
+
 0.3.1 (2026-03-06)
 ------------------
 Contributors to this version: Ludwig Lierhammer (:user:`ludwiglierhammer`), John Kennedy (:user:`jjk-code-otter`) and Trevor James Smith (:user:`Zeitsperre`)

--- a/src/marine_qc/qc_individual_reports.py
+++ b/src/marine_qc/qc_individual_reports.py
@@ -175,7 +175,7 @@ def do_date_check(
         year_ok[year_valid < year_init] = False
     if year_end:
         year_ok[year_valid > year_end] = False
-    
+
     month_ok = (month_valid >= 1) & (month_valid <= 12)
 
     unique_years = np.unique(year_valid)

--- a/src/marine_qc/qc_individual_reports.py
+++ b/src/marine_qc/qc_individual_reports.py
@@ -122,6 +122,8 @@ def do_date_check(
     year: ValueIntType | None = None,
     month: ValueIntType | None = None,
     day: ValueIntType | None = None,
+    year_init: int | None = None,
+    year_end: int | None = None,
 ) -> ValueIntType:
     """
     Perform the date QC check on the report. Checks whether the given date or date components are valid.
@@ -140,6 +142,10 @@ def do_date_check(
     day : int, None, sequence of int or None, 1D np.ndarray of int, or pd.series of int, optional
         Day(s) of observation.
         Can be a scalar, a sequence (e.g., list or tuple), a one-dimensional NumPy array, or a pandas Series.
+    year_init : int, optional
+        Initial valid year.
+    year_end : int, optional
+        Last valid year.
 
     Returns
     -------
@@ -164,7 +170,12 @@ def do_date_check(
 
     result_valid = np.full(year_valid.shape, failed, dtype=int)
 
-    year_ok = (year_valid >= 1850) & (year_valid <= 2025)
+    year_ok = np.full(year_valid.shape, True, dtype=bool)
+    if year_init:
+        year_ok[year_valid < year_init] = False
+    if year_end:
+        year_ok[year_valid > year_end] = False
+    
     month_ok = (month_valid >= 1) & (month_valid <= 12)
 
     unique_years = np.unique(year_valid)

--- a/tests/test_individual_report_qc.py
+++ b/tests/test_individual_report_qc.py
@@ -174,13 +174,27 @@ def test_do_date_check_using_date(year, month, day, expected):
     assert result == expected
 
 
-def _test_do_date_check_raises_value_error():
-    # Make sure that an exception is raised if year or month is set to None
-    with pytest.raises(ValueError):
-        _ = do_date_check(year=None, month=1, day=1)
-    with pytest.raises(ValueError):
-        _ = do_date_check(year=1850, month=None, day=1)
+def test_do_date_check_untestable():
+    result = do_date_check(year=None, month=1, day=1)
+    assert result == 2
+    result = do_date_check(year=2022, month=None, day=1)
+    assert result == 2
+    result = do_date_check(year=2022, month=1, day=None)
+    assert result == 2
 
+@pytest.mark.parametrize(
+    "year, month, day, expected",
+    [
+        (2022, 1, 1, failed),  # 1st January 2022 FAIL
+        (2023, 1, 1, passed),  # 1st January 2023 PASS
+        (2024, 1, 1, passed),  # 1st January 2024 PASS
+        (2025, 1, 1, passed),  # 1st January 2025 PASS
+        (2026, 1, 1, failed),  # 1st January 2026 FAIL
+    ],
+)
+def test_do_date_check_year_range(year, month, day, expected):
+    result = do_date_check(year=year, month=month, day=day, year_init=2023, year_end=2025)
+    assert result == expected
 
 @pytest.mark.parametrize(
     "hour, expected",

--- a/tests/test_individual_report_qc.py
+++ b/tests/test_individual_report_qc.py
@@ -182,6 +182,7 @@ def test_do_date_check_untestable():
     result = do_date_check(year=2022, month=1, day=None)
     assert result == 2
 
+
 @pytest.mark.parametrize(
     "year, month, day, expected",
     [
@@ -195,6 +196,7 @@ def test_do_date_check_untestable():
 def test_do_date_check_year_range(year, month, day, expected):
     result = do_date_check(year=year, month=month, day=day, year_init=2023, year_end=2025)
     assert result == expected
+
 
 @pytest.mark.parametrize(
     "hour, expected",


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes no issue.
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* `do_date_check` has a hard-coded year range for which years are valid
* We replace those hard-coded range with some new flexible input parameters: `year_init` and `year_end` 

### Does this PR introduce a breaking change?
No breaking change but new optional parameters in `do_date_check`

### Other information:
