### PR TITLE
make `do_missing_value_check` name consistent and implement `do_valid_value_check`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Changelog
 =========
 
+0.3.3 (unreleased)
+------------------
+Contributors to this version: Ludwig Lierhammer (:user:`ludwiglierhammer`)
+
+New features and environments
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* new_functions: `do_valid_value_check` and `do_valid_value_clim_check` are copies of the old versions from `do_missing_value_check` and `do_missing_value_clim_check` that return `1` (fail) for numerically invalid values, otherwise `0` (pass) (:issue:`205`, :pull:`206`)
+
+Breaking changes
+^^^^^^^^^^^^^^^^
+* Both `do_mising_value_check` and `do_missing_value_clim_check` now return `0` (pass) for numerically invalid values, otherwise `1` (fail) (:issue:`205`, :pull:`206`)
+
 0.3.2 (2023-04-21)
 ------------------
 Contributors to this version: Ludwig Lierhammer (:user:`ludwiglierhammer`), Trevor James Smith (:user:`Zeitsperre`)

--- a/docs/api/api_main_ind.rst
+++ b/docs/api/api_main_ind.rst
@@ -3,6 +3,18 @@
 QC checks on individual reports
 -------------------------------
 
+.. autofunction:: marine_qc.do_valid_value_check
+   :noindex:
+
+.. autofunction:: marine_qc.do_valid_value_clim_check
+   :noindex:
+
+.. autofunction:: marine_qc.do_missing_value_check
+   :noindex:
+
+.. autofunction:: marine_qc.do_missing_value_clim_check
+   :noindex:
+
 .. autofunction:: marine_qc.do_position_check
    :noindex:
 
@@ -13,12 +25,6 @@ QC checks on individual reports
    :noindex:
 
 .. autofunction:: marine_qc.do_day_check
-   :noindex:
-
-.. autofunction:: marine_qc.do_missing_value_check
-   :noindex:
-
-.. autofunction:: marine_qc.do_missing_value_clim_check
    :noindex:
 
 .. autofunction:: marine_qc.do_night_check

--- a/docs/overview_ind.rst
+++ b/docs/overview_ind.rst
@@ -79,7 +79,7 @@ definition of day is between a specified amount of time after sunrise and the sa
 any of the inputs are numerically invalid, the flag is set to 2, untestable.
 
 :func:`.do_night_check`
-=====================
+=======================
 
 Tests whether the report was during the night.
 

--- a/docs/overview_ind.rst
+++ b/docs/overview_ind.rst
@@ -191,6 +191,8 @@ Currently, the following QC checks can be used:
 * :func:`.do_supersaturation_check`,
 * :func:`.do_time_check`,
 * :func:`.do_wind_consistency_check`
+* :func:`.do_valid_value_check`,
+* :func:`.do_valid_value_clim_check`,
 
 And the following preprocessing functions:
 

--- a/docs/overview_ind.rst
+++ b/docs/overview_ind.rst
@@ -13,6 +13,38 @@ The tests in `qc_individual_reports.py` work on individual marine reports, eithe
 change the outcome). These include simple checks of whether the location, time and date of the observation are
 valid as well as more complex checks involving comparison to climatologies.
 
+:func:`.do_valid_value_check`
+===============================
+
+Tests that the value is present.
+
+Checks whether a value is None or numerically invalid. If the report is numerically invalid the flag is set to 1, fail,
+otherwise it is set to 0, pass.
+
+:func:`.do_valid_value_clim_check`
+====================================
+
+Tests whether there is a valid climatological value at the report location.
+
+Checks whether a value in a report was made at a location with a valid climatological average. If the climatological
+value is valid, the flag is set to 0, pass otherwise it is set to 1, fail.
+
+:func:`.do_missing_value_check`
+===============================
+
+Tests that the value is present.
+
+Checks whether a value is None or numerically invalid. If the report is numerically invalid the flag is set to 0, pass,
+otherwise it is set to 1, fail.
+
+:func:`.do_missing_value_clim_check`
+====================================
+
+Tests whether there is a valid climatological value at the report location.
+
+Checks whether a value in a report was made at a location with a valid climatological average. If the climatological
+value is valid, the flag is set to 1, fail otherwise it is set to 0, pass.
+
 :func:`.do_position_check`
 ==========================
 
@@ -42,25 +74,19 @@ like) then the flag is set to 2, i.e. untestable.
 
 Tests whether the report was during the day.
 
+Checks whether an observation was made during the day (flag set to 0, pass) or night (flag set to 1, fail). The
+definition of day is between a specified amount of time after sunrise and the same amount of time after sunset. If
+any of the inputs are numerically invalid, the flag is set to 2, untestable.
+
+:func:`.do_night_check`
+=====================
+
+Tests whether the report was during the night.
+
 Checks whether an observation was made during the day (flag set to 1, fail) or night (flag set to 0, pass). The
 definition of day is between a specified amount of time after sunrise and the same amount of time after sunset. If
 any of the inputs are numerically invalid, the flag is set to 2, untestable.
 
-:func:`.do_missing_value_check`
-===============================
-
-Tests that the value is present.
-
-Checks whether a value is None or numerically invalid. If the report is numerically invalid the flag is set to 1, fail,
-otherwise it is set to 0, pass.
-
-:func:`.do_missing_value_clim_check`
-====================================
-
-Tests whether there is a valid climatological value at the report location.
-
-Checks whether a value in a report was made at a location with a valid climatological average. If the climatological
-value is valid, the flag is set to 0, pass otherwise it is set to 1, fail.
 
 :func:`.do_hard_limit_check`
 ============================

--- a/src/marine_qc/__init__.py
+++ b/src/marine_qc/__init__.py
@@ -57,6 +57,8 @@ from .qc_individual_reports import (
     do_sst_freeze_check,
     do_supersaturation_check,
     do_time_check,
+    do_valid_value_check,
+    do_valid_value_clim_check,
     do_wind_consistency_check,
 )
 from .qc_sequential_reports import (

--- a/src/marine_qc/qc_individual_reports.py
+++ b/src/marine_qc/qc_individual_reports.py
@@ -36,7 +36,7 @@ vectorized_sunangle = np.vectorize(sunangle, otypes=[float, float, float, float,
 
 @post_format_return_type(["value"])
 @inspect_arrays(["value"])
-def value_check(value: ValueNumberType) -> ValueIntType:
+def value_check(value: ValueNumberType, valid_flag: int = passed, invalid_flag: int = failed) -> ValueIntType:
     """
     Check if a value is equal to None or numerically invalid (NaN).
 
@@ -45,6 +45,10 @@ def value_check(value: ValueNumberType) -> ValueIntType:
     value : :py:obj:`~marine_qc.ValueNumberType`
         The input value(s) to be tested.
         Can be a scalar, sequence (e.g., list or tuple), a one-dimensional NumPy array, or a pandas Series.
+    valid_flag : int, default: 0
+        Integer value how to flag valid values.
+    invalid_flag : int, default: 1
+        Integer value how to flag invalid values.
 
     Returns
     -------
@@ -62,7 +66,7 @@ def value_check(value: ValueNumberType) -> ValueIntType:
     (value_arr,) = ensure_arrays(value=value)
 
     valid_mask = isvalid(value_arr)
-    result = np.where(valid_mask, passed, failed)
+    result = np.where(valid_mask, valid_flag, invalid_flag)
 
     return result
 
@@ -551,6 +555,67 @@ def do_missing_value_check(value: ValueNumberType) -> ValueIntType:
     :py:obj:`~marine_qc.ValueIntType`
         Same type as input, but with integer values
 
+        - Returns 0 (or array/sequence/Series of 1s) if the input value is None or numerically invalid (NaN)
+        - Returns 1 (or array/sequence/Series of 0s) otherwise.
+
+    Raises
+    ------
+    TypeError
+        If decorator `inspect_arrays` in :py:func:`value_check` does not return np.ndarrays.
+    """
+    return value_check(value, valid_flag=failed, invalid_flag=passed)
+
+
+@inspect_climatology("climatology")
+def do_missing_value_clim_check(climatology: ClimArgType, **kwargs: Any) -> ValueIntType:
+    r"""
+    Check if a climatological value is equal to None or numerically invalid (NaN).
+
+    Parameters
+    ----------
+    climatology : :py:obj:`~marine_qc.ClimArgType`
+        The input climatological value(s) to be tested.
+        Can be a scalar, sequence, a one-dimensional NumPy array, a pandas Series,
+        a :py:class:`~marine_qc.Climatology`, a path-like string on disk, a xarray Dataset or a xarray DataArray.
+    \**kwargs : dict
+        Additional keyword arguments passed by the decorator framework (unused).
+
+    Returns
+    -------
+    :py:obj:`~marine_qc.ValueIntType`
+        Same type as input, but with integer values
+
+        - Returns 0 (or array/sequence/Series of 1s) if the input value is None or numerically invalid (NaN)
+        - Returns 1 (or array/sequence/Series of 0s) otherwise.
+
+    Raises
+    ------
+    TypeError
+        If decorator `inspect_arrays` in :py:func:`value_check` does not return np.ndarrays.
+
+    Notes
+    -----
+    If `climatology` is a :py:class:`~marine_qc.Climatology` object, pass `lon` and `lat` and `date`, or `month` and `day`,
+    as keyword arguments to extract the relevant climatological value.
+    """
+    return value_check(climatology, valid_flag=failed, invalid_flag=passed)
+
+
+def do_valid_value_check(value: ValueNumberType) -> ValueIntType:
+    """
+    Check if a value is not equal to None or numerically valid.
+
+    Parameters
+    ----------
+    value : :py:obj:`~marine_qc.ValueNumberType`
+        The input value(s) to be tested.
+        Can be a scalar, sequence (e.g., list or tuple), a one-dimensional NumPy array, or a pandas Series.
+
+    Returns
+    -------
+    :py:obj:`~marine_qc.ValueIntType`
+        Same type as input, but with integer values
+
         - Returns 1 (or array/sequence/Series of 1s) if the input value is None or numerically invalid (NaN)
         - Returns 0 (or array/sequence/Series of 0s) otherwise.
 
@@ -563,9 +628,9 @@ def do_missing_value_check(value: ValueNumberType) -> ValueIntType:
 
 
 @inspect_climatology("climatology")
-def do_missing_value_clim_check(climatology: ClimArgType, **kwargs: Any) -> ValueIntType:
+def do_valid_value_clim_check(climatology: ClimArgType, **kwargs: Any) -> ValueIntType:
     r"""
-    Check if a climatological value is equal to None or numerically invalid (NaN).
+    Check if a climatological value is not equal to None or numerically valid.
 
     Parameters
     ----------

--- a/tests/test_individual_report_qc.py
+++ b/tests/test_individual_report_qc.py
@@ -20,6 +20,8 @@ from marine_qc import (
     do_sst_freeze_check,
     do_supersaturation_check,
     do_time_check,
+    do_valid_value_check,
+    do_valid_value_clim_check,
     do_wind_consistency_check,
 )
 from marine_qc.auxiliary import (
@@ -132,12 +134,9 @@ def test_do_position_check(latitude, longitude, expected):
     assert do_position_check(latitude, longitude, units=units) == expected
 
 
-def _test_do_position_check_raises_value_error():
-    # Make sure that an exception is raised if latitude or longitude is missing
-    with pytest.raises(ValueError):
-        _ = do_position_check(None, 0.0)
-    with pytest.raises(ValueError):
-        _ = do_position_check(0.0, None)
+def test_do_position_check_untestable():
+    assert do_position_check(None, 0.0) == 2
+    assert do_position_check(0.0, None) == 2
 
 
 @pytest.mark.parametrize(
@@ -450,22 +449,30 @@ def test_do_night_check(year, month, day, hour, latitude, longitude, time, expec
     assert result == expected
 
 
-@pytest.mark.parametrize("at, expected", [(5.6, passed), (None, failed), (np.nan, failed)])  # not sure if np.nan should trigger FAIL
-def test_do_air_temperature_missing_value_check(at, expected):
-    assert do_missing_value_check(at) == expected
+@pytest.mark.parametrize("value, expected", [(5.6, failed), (None, passed), (np.nan, passed)])  # not sure if np.nan should trigger FAIL
+def test_do_missing_value_check(value, expected):
+    assert do_missing_value_check(value) == expected
 
 
 @pytest.mark.parametrize(
-    "at_climatology, expected",
+    "clim, expected",
+    [(5.5, failed), (None, passed), (np.nan, passed), (56, failed)],
+)  # not sure if np.nan should trigger FAIL
+def test_do_missing_value_clim_check(clim, expected):
+    assert do_missing_value_clim_check(clim) == expected
+
+
+@pytest.mark.parametrize("value, expected", [(5.6, passed), (None, failed), (np.nan, failed)])  # not sure if np.nan should trigger FAIL
+def test_do_valid_value_check(value, expected):
+    assert do_valid_value_check(value) == expected
+
+
+@pytest.mark.parametrize(
+    "clim, expected",
     [(5.5, passed), (None, failed), (np.nan, failed), (56, passed)],
 )  # not sure if np.nan should trigger FAIL
-def test_do_air_temperature_missing_value_clim_check(at_climatology, expected):
-    assert do_missing_value_clim_check(at_climatology) == expected
-
-
-@pytest.mark.parametrize("sst, expected", [(5.6, passed), (None, failed), (np.nan, failed)])  # not sure if np.nan should trigger FAIL
-def test_do_sst_missing_value_check(sst, expected):
-    assert do_missing_value_check(sst) == expected
+def test_do_valid_value_clim_check(clim, expected):
+    assert do_valid_value_clim_check(clim) == expected
 
 
 # fmt: off


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #205
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Update both `do_missing_value_check` and `do_missing_value_clim_check` to return `0` for numerically invalid values, otherwise `1`.
* add new functions:

  * `do_valid_value_check`: copy of the old `do_missing_value_check`
  * `do_valid_value_clim_check`: copy of old `do_missing_value_clim_check`

### Does this PR introduce a breaking change?

* `do_missing_value_check` now returns `0` instead of `1` for numerically invalid values
* `do_missing_value_clim_check` now returns `0` instead of `1` for numerically invalid values

### Other information:
This PR is made for naming consistency reasons.