### PR TITLE
Improve plotting routines

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,9 @@ New features and environments
 * new_functions: `do_valid_value_check` and `do_valid_value_clim_check` are copies of the old versions from `do_missing_value_check` and `do_missing_value_clim_check` that return `1` (fail) for numerically invalid values, otherwise `0` (pass) (:issue:`205`, :pull:`206`)
 * A new checker to detect (``marine_qc.duplicate_check``), get (``marine_qc.get_duplicates``), flag (``marine_qc.flag_duplicates``) and remove (``marine_qc.remove_duplicates``) potentially duplicated observations using ``splink`` (:issue:`202`, :issue:`210`, :pull:`207`)
 * flag definitions can now directly be imported via ``marine_qc.Flags`` (:pull:`207`)
+* new plotting routine that plots a graph of points showing the longitude and value of a set of observations coloured according to flagged outcomes: ``plot_variable_longitude`` (:issue:`240`, :pull:`244`)
+* add new input parameters ``xlim`` and ``ylim`` in the plotting routines (:issue:`240`, :pull:`244`)
+* add new input parameter ``marker_size`` in the plotting routines (:issue:`240`, :pull:`244`)
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
@@ -24,6 +27,7 @@ Internal changes
 * move visualization modules to ``src.marine_qc.visualization`` (:pull:`207`)
 * locally import some members in submodules ``src.marine_qc.duplicate_checker``, ``src.marine_qc.helpers``, ``src.marine_qc.quality_control`` and ``src.marine_qc.visualization`` (:pull:`207`)
 * Upload coverage results to Coveralls instead of Codecov (:issue:`58`, :pull:`232`, :pull:`233`)
+* rename plotting routines: ``latitude_longitude_plot`` to ``plot_latitude_longitude`` and ``latitude_variable_plot`` to ``plot_latitude_variable`` (:issue:`240`, :pull:`244`)
 
 0.3.2 (2023-04-21)
 ------------------

--- a/docs/api/api_main_plt.rst
+++ b/docs/api/api_main_plt.rst
@@ -3,8 +3,11 @@
 Visualization of quality control or duplicate flags
 ---------------------------------------------------
 
-.. autofunction:: marine_qc.latitude_longitude_plot
+.. autofunction:: marine_qc.plot_latitude_longitude
    :noindex:
 
-.. autofunction:: marine_qc.latitude_variable_plot
+.. autofunction:: marine_qc.plot_latitude_variable
+   :noindex:
+
+.. autofunction:: marine_qc.plot_variable_longitude
    :noindex:

--- a/src/marine_qc/__init__.py
+++ b/src/marine_qc/__init__.py
@@ -70,8 +70,9 @@ from .quality_control import (
     find_saturated_runs,
 )
 from .visualization import (
-    latitude_longitude_plot,
-    latitude_variable_plot,
+    plot_latitude_longitude,
+    plot_latitude_variable,
+    plot_variable_longitude,
 )
 
 

--- a/src/marine_qc/visualization/__init__.py
+++ b/src/marine_qc/visualization/__init__.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from .plot_qc_outcomes import latitude_longitude_plot, latitude_variable_plot
+from .plot_qc_outcomes import plot_latitude_longitude, plot_latitude_variable, plot_variable_longitude
 
 
 __all__ = [
-    "latitude_longitude_plot",
-    "latitude_variable_plot",
+    "plot_latitude_longitude",
+    "plot_latitude_variable",
+    "plot_variable_longitude",
 ]

--- a/src/marine_qc/visualization/plot_qc_outcomes.py
+++ b/src/marine_qc/visualization/plot_qc_outcomes.py
@@ -157,7 +157,7 @@ def _make_plot(
     return fig
 
 
-def variable_longitude_plot(
+def plot_variable_longitude(
     lon: np.ndarray,
     value: np.ndarray,
     qc_outcomes: np.ndarray,
@@ -206,7 +206,7 @@ def variable_longitude_plot(
     )
 
 
-def latitude_variable_plot(
+def plot_latitude_variable(
     lat: np.ndarray,
     value: np.ndarray,
     qc_outcomes: np.ndarray,
@@ -255,7 +255,7 @@ def latitude_variable_plot(
     )
 
 
-def latitude_longitude_plot(
+def plot_latitude_longitude(
     lat: np.ndarray,
     lon: np.ndarray,
     qc_outcomes: np.ndarray,
@@ -306,6 +306,6 @@ def latitude_longitude_plot(
     )
 
 
-latitude_longitude_plot.__module__ = "marine_qc.visualization"
-latitude_variable_plot.__module__ = "marine_qc.visualization"
-variable_longitude_plot.__module__ = "marine_qc.visualization"
+plot_latitude_longitude.__module__ = "marine_qc.visualization"
+plot_latitude_variable.__module__ = "marine_qc.visualization"
+plot_variable_longitude.__module__ = "marine_qc.visualization"

--- a/src/marine_qc/visualization/plot_qc_outcomes.py
+++ b/src/marine_qc/visualization/plot_qc_outcomes.py
@@ -78,10 +78,11 @@ def _make_plot(
     xvalue: np.ndarray,
     yvalue: np.ndarray,
     flags: np.ndarray,
-    xlim: list[float] | None,
-    ylim: list[float] | None,
+    xlim: tuple[float, float] | None,
+    ylim: tuple[float, float] | None,
     xlabel: str,
     ylabel: str,
+    marker_size: int | None,
     filename: str | None,
 ) -> figure.Figure:
     """
@@ -95,16 +96,18 @@ def _make_plot(
         Array of y values.
     flags : numpy.ndarray
         Array containing the QC outcomes, with 0 meaning pass and non-zero entries indicating failure.
-    xlim : list of float or None
+    xlim : tuple of float and float or None
         If not None: set xlim for plotting.
-    ylim : list of float or None
+    ylim : tuple of float and float or None
         If not None: set ylim for plotting.
     xlabel : str
         Name of the x axis.
     ylabel : str
         Name of the y axis.
+    marker_size : int
+        Marker size in points.
     filename : str or None
-        Filename to save the figure to. If None, the figure is saved with a standard name.
+        Filename to save the figure to. If None, the figure is not saved nut shown.
 
     Returns
     -------
@@ -124,9 +127,11 @@ def _make_plot(
 
     masks = [mask_passed, mask_failed, mask_other, np.ones_like(flags, dtype=bool)]
 
+    marker_size = marker_size or 1
+
     for i in range(4):
         ax = axes[i]
-        ax.scatter(xvalue[masks[i]], yvalue[masks[i]], c=colours[masks[i]], s=1)
+        ax.scatter(xvalue[masks[i]], yvalue[masks[i]], c=colours[masks[i]], s=marker_size)
         ax.set_title(titles[i])
         ax.set_xlabel(xlabel)
         ax.set_ylabel(ylabel)
@@ -151,7 +156,16 @@ def _make_plot(
 
     return fig
 
-def variable_longitude_plot(lat: np.ndarray, value: np.ndarray, qc_outcomes: np.ndarray, filename: str | None = None) -> figure.Figure:
+
+def variable_longitude_plot(
+    lon: np.ndarray,
+    value: np.ndarray,
+    qc_outcomes: np.ndarray,
+    xlim: tuple[float, float] | None,
+    ylim: tuple[float, float] | None,
+    marker_size: int | None = None,
+    filename: str | None = None,
+) -> figure.Figure:
     """
     Plot a graph of points showing the value and the longitude of a set of observations coloured according to flagged outcomes.
 
@@ -163,26 +177,44 @@ def variable_longitude_plot(lat: np.ndarray, value: np.ndarray, qc_outcomes: np.
         Array of observed values for the variable.
     qc_outcomes : numpy.ndarray
         Array containing the QC outcomes, with 0 meaning pass and non-zero entries indicating failure.
-    filename : str or None
-        Filename to save the figure to. If None, the figure is saved with a standard name.
+    xlim : tuple of float and float, optional
+        Limits of the current x axis. If None, set to (-180.0, 180.0).
+    ylim : tuple of float and float, optional
+        Limits of the current y axis.
+    marker_size : int, optional
+        Marker size in points. If None, it is set to 1.
+    filename : str, optional
+        Filename to save the figure to. If None, the figure is not saved but shown.
 
     Returns
     -------
     Figure
         The main figure object created by `plt.subplots()`.
     """
+    if xlim is None:
+        xlim = (-180.0, 180.0)
     return _make_plot(
         xvalue=lon,
         yvalue=value,
         flags=qc_outcomes,
-        xlim=[-180.0,180.0],
+        xlim=None,
         ylim=None,
         xlabel="Longitude",
         ylabel="Variable",
+        marker_size=marker_size,
         filename=filename,
     )
 
-def latitude_variable_plot(lat: np.ndarray, value: np.ndarray, qc_outcomes: np.ndarray, filename: str | None = None) -> figure.Figure:
+
+def latitude_variable_plot(
+    lat: np.ndarray,
+    value: np.ndarray,
+    qc_outcomes: np.ndarray,
+    xlim: tuple[float, float] | None,
+    ylim: tuple[float, float] | None,
+    marker_size: int | None = None,
+    filename: str | None = None,
+) -> figure.Figure:
     """
     Plot a graph of points showing the latitude and the value of a set of observations coloured according to flagged outcomes.
 
@@ -194,27 +226,44 @@ def latitude_variable_plot(lat: np.ndarray, value: np.ndarray, qc_outcomes: np.n
         Array of observed values for the variable.
     qc_outcomes : numpy.ndarray
         Array containing the QC outcomes, with 0 meaning pass and non-zero entries indicating failure.
-    filename : str or None
-        Filename to save the figure to. If None, the figure is saved with a standard name.
+    xlim : tuple of float and float, optional
+        Limits of the current x axis.
+    ylim : tuple of float and float, optional
+        Limits of the current y axis. If None, set to (-90.0, 90.0).
+    marker_size : int, optional
+        Marker size in points. If None, it is set to 1.
+    filename : str, optional
+        Filename to save the figure to. If None, the figure is not saved but shown.
 
     Returns
     -------
     Figure
         The main figure object created by `plt.subplots()`.
     """
+    if ylim is None:
+        ylim = (-90.0, 90.0)
     return _make_plot(
         xvalue=value,
         yvalue=lat,
         flags=qc_outcomes,
         xlim=None,
-        ylim=[-90.0, 90.0],
+        ylim=ylim,
         xlabel="Variable",
         ylabel="Latitude",
+        marker_size=marker_size,
         filename=filename,
     )
 
 
-def latitude_longitude_plot(lat: np.ndarray, lon: np.ndarray, qc_outcomes: np.ndarray, filename: str | None = None) -> figure.Figure:
+def latitude_longitude_plot(
+    lat: np.ndarray,
+    lon: np.ndarray,
+    qc_outcomes: np.ndarray,
+    xlim: tuple[float, float] | None,
+    ylim: tuple[float, float] | None,
+    marker_size: int | None = None,
+    filename: str | None = None,
+) -> figure.Figure:
     """
     Plot a graph of points showing the latitude and the longitude of a set of observations coloured according to flagged outcomes.
 
@@ -226,25 +275,37 @@ def latitude_longitude_plot(lat: np.ndarray, lon: np.ndarray, qc_outcomes: np.nd
         Array of longitude values in degrees.
     qc_outcomes : numpy.ndarray
         Array containing the QC outcomes, with 0 meaning pass and non-zero entries indicating failure.
-    filename : str or None
-        Filename to save the figure to. If None, the figure is saved with a standard name.
+    xlim : tuple of float and float, optional
+        Limits of the current x axis. If None, set to (-180.0, 180.0).
+    ylim : tuple of float and float, optional
+        Limits of the current y axis. If None, set to (-90.0, 90.0).
+    marker_size : int, optional
+        Marker size in points. If None, it is set to 1.
+    filename : str, optional
+        Filename to save the figure to. If None, the figure is not saved but shown.
 
     Returns
     -------
     Figure
         The main figure object created by `plt.subplots()`.
     """
+    if xlim is None:
+        xlim = (-180.0, 180.0)
+    if ylim is None:
+        ylim = (-90.0, 90.0)
     return _make_plot(
         xvalue=lon,
         yvalue=lat,
         flags=qc_outcomes,
-        xlim=[-180.0, 180.0],
-        ylim=[-90.0, 90.0],
+        xlim=xlim,
+        ylim=ylim,
         xlabel="Longitude",
         ylabel="Latitude",
+        marker_size=marker_size,
         filename=filename,
     )
 
 
 latitude_longitude_plot.__module__ = "marine_qc.visualization"
 latitude_variable_plot.__module__ = "marine_qc.visualization"
+variable_longitude_plot.__module__ = "marine_qc.visualization"

--- a/src/marine_qc/visualization/plot_qc_outcomes.py
+++ b/src/marine_qc/visualization/plot_qc_outcomes.py
@@ -151,10 +151,40 @@ def _make_plot(
 
     return fig
 
+def variable_longitude_plot(lat: np.ndarray, value: np.ndarray, qc_outcomes: np.ndarray, filename: str | None = None) -> figure.Figure:
+    """
+    Plot a graph of points showing the value and the longitude of a set of observations coloured according to flagged outcomes.
+
+    Parameters
+    ----------
+    lon : numpy.ndarray
+        Array of longitude values in degrees.
+    value : numpy.ndarray
+        Array of observed values for the variable.
+    qc_outcomes : numpy.ndarray
+        Array containing the QC outcomes, with 0 meaning pass and non-zero entries indicating failure.
+    filename : str or None
+        Filename to save the figure to. If None, the figure is saved with a standard name.
+
+    Returns
+    -------
+    Figure
+        The main figure object created by `plt.subplots()`.
+    """
+    return _make_plot(
+        xvalue=lon,
+        yvalue=value,
+        flags=qc_outcomes,
+        xlim=[-180.0,180.0],
+        ylim=None,
+        xlabel="Longitude",
+        ylabel="Variable",
+        filename=filename,
+    )
 
 def latitude_variable_plot(lat: np.ndarray, value: np.ndarray, qc_outcomes: np.ndarray, filename: str | None = None) -> figure.Figure:
     """
-    Plot a graph of points showing the latitude and value of a set of observations coloured according to flagged outcomes.
+    Plot a graph of points showing the latitude and the value of a set of observations coloured according to flagged outcomes.
 
     Parameters
     ----------
@@ -170,7 +200,7 @@ def latitude_variable_plot(lat: np.ndarray, value: np.ndarray, qc_outcomes: np.n
     Returns
     -------
     Figure
-        The main figure obkect created by `plt.subplots()`.
+        The main figure object created by `plt.subplots()`.
     """
     return _make_plot(
         xvalue=value,
@@ -186,7 +216,7 @@ def latitude_variable_plot(lat: np.ndarray, value: np.ndarray, qc_outcomes: np.n
 
 def latitude_longitude_plot(lat: np.ndarray, lon: np.ndarray, qc_outcomes: np.ndarray, filename: str | None = None) -> figure.Figure:
     """
-    Plot a graph of points showing the latitude and longitude of a set of observations coloured according to flagged outcomes.
+    Plot a graph of points showing the latitude and the longitude of a set of observations coloured according to flagged outcomes.
 
     Parameters
     ----------
@@ -202,7 +232,7 @@ def latitude_longitude_plot(lat: np.ndarray, lon: np.ndarray, qc_outcomes: np.nd
     Returns
     -------
     Figure
-        The main figure obkect created by `plt.subplots()`.
+        The main figure object created by `plt.subplots()`.
     """
     return _make_plot(
         xvalue=lon,

--- a/src/marine_qc/visualization/plot_qc_outcomes.py
+++ b/src/marine_qc/visualization/plot_qc_outcomes.py
@@ -161,8 +161,8 @@ def plot_variable_longitude(
     lon: np.ndarray,
     value: np.ndarray,
     qc_outcomes: np.ndarray,
-    xlim: tuple[float, float] | None,
-    ylim: tuple[float, float] | None,
+    xlim: tuple[float, float] | None = None,
+    ylim: tuple[float, float] | None = None,
     marker_size: int | None = None,
     filename: str | None = None,
 ) -> figure.Figure:
@@ -210,8 +210,8 @@ def plot_latitude_variable(
     lat: np.ndarray,
     value: np.ndarray,
     qc_outcomes: np.ndarray,
-    xlim: tuple[float, float] | None,
-    ylim: tuple[float, float] | None,
+    xlim: tuple[float, float] | None = None,
+    ylim: tuple[float, float] | None = None,
     marker_size: int | None = None,
     filename: str | None = None,
 ) -> figure.Figure:
@@ -259,8 +259,8 @@ def plot_latitude_longitude(
     lat: np.ndarray,
     lon: np.ndarray,
     qc_outcomes: np.ndarray,
-    xlim: tuple[float, float] | None,
-    ylim: tuple[float, float] | None,
+    xlim: tuple[float, float] | None = None,
+    ylim: tuple[float, float] | None = None,
     marker_size: int | None = None,
     filename: str | None = None,
 ) -> figure.Figure:

--- a/tests/test_plot_qc_outcomes.py
+++ b/tests/test_plot_qc_outcomes.py
@@ -31,6 +31,7 @@ def test_make_plot(tmp_path):
         "ylim": None,
         "xlabel": "longitude",
         "ylabel": "latitude",
+        "marker_size": 1,
     }
     fig = _make_plot(
         **plot_kwargs,
@@ -68,8 +69,8 @@ def test_plot_latitude_longitude():
 
 def test_plot_variable_longitude():
     fig = plot_variable_longitude(
-        lat=np.array([-10, 0, 10]),
         lon=np.array([-10, 0, 10]),
+        value=np.array([5, 6, 7]),
         qc_outcomes=np.array([0, 1, 2]),
     )
     plt.close(fig)

--- a/tests/test_plot_qc_outcomes.py
+++ b/tests/test_plot_qc_outcomes.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.lines import Line2D
 
-from marine_qc.visualization import latitude_longitude_plot, latitude_variable_plot
+from marine_qc.visualization import plot_latitude_longitude, plot_latitude_variable, plot_variable_longitude
 from marine_qc.visualization.plot_qc_outcomes import (
     _get_colours_labels,
     _make_plot,
@@ -48,8 +48,8 @@ def test_make_plot(tmp_path):
     filename.unlink()
 
 
-def test_latitude_variable_plot():
-    fig = latitude_variable_plot(
+def test_plot_latitude_variable():
+    fig = plot_latitude_variable(
         lat=np.array([-10, 0, 10]),
         value=np.array([5, 6, 7]),
         qc_outcomes=np.array([0, 1, 2]),
@@ -57,8 +57,17 @@ def test_latitude_variable_plot():
     plt.close(fig)
 
 
-def test_latitude_longitude_plot():
-    fig = latitude_longitude_plot(
+def test_plot_latitude_longitude():
+    fig = plot_latitude_longitude(
+        lat=np.array([-10, 0, 10]),
+        lon=np.array([-10, 0, 10]),
+        qc_outcomes=np.array([0, 1, 2]),
+    )
+    plt.close(fig)
+
+
+def test_plot_variable_longitude():
+    fig = plot_variable_longitude(
         lat=np.array([-10, 0, 10]),
         lon=np.array([-10, 0, 10]),
         qc_outcomes=np.array([0, 1, 2]),


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #240
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* add a new plotting routine that plots a graph of points showing the longitude and value of a set of observations coloured according to flagged outcomes: `plot_variable_longitude`
* add new input parameters `xlim` and `ylim` in the plotting routines
* add new input parameter `marker_size`

### Does this PR introduce a breaking change?

Rename plotting routines:

* `latitude_longitude_plot` to `plot_latitude_longitude`
* `latitude_variable_plot` to `plot_latitude_variable`

### Other information:
