### PR TITLE
fixing mypy hook

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,8 +30,9 @@ Internal changes
 * locally import some members in submodules ``src.marine_qc.duplicate_checker``, ``src.marine_qc.helpers``, ``src.marine_qc.quality_control`` and ``src.marine_qc.visualization`` (:pull:`207`)
 * Upload coverage results to Coveralls instead of Codecov (:issue:`58`, :pull:`232`, :pull:`233`)
 * rename plotting routines: ``latitude_longitude_plot`` to ``plot_latitude_longitude`` and ``latitude_variable_plot`` to ``plot_latitude_variable`` (:issue:`240`, :pull:`244`)
-* new helper function quality_control.qc_individual_report._do_time_check that is used in both do_time_check and do_datetime_check (:pull:`246`)
-* new helper function quality_control.qc_individual_report._do_date_check that is used in both do_date_check and do_datetime_check (:pull:`246`)
+* new helper function ``quality_control.qc_individual_report._do_time_check`` that is used in both "do_time_check" and "do_datetime_check" (:pull:`246`)
+* new helper function ``quality_control.qc_individual_report._do_date_check`` that is used in both "do_date_check" and "do_datetime_check" (:pull:`246`)
+* explicitly convert intermediate result in ``quality_control.helpers.time_control.dayin_year`` to a python integer to fix incompatible types assignment (:pull:`247`)
 
 0.3.2 (2023-04-21)
 ------------------

--- a/src/marine_qc/helpers/time_control.py
+++ b/src/marine_qc/helpers/time_control.py
@@ -452,7 +452,7 @@ def day_in_year(year: int | None = None, month: int = 1, day: int = 1) -> int:
     elif year_not_specified and month == 2 and day == 29:
         day_index = day_in_year(month=3, day=1)
     else:
-        day_index = np.sum(month_lengths[0 : month - 1]) + day
+        day_index = int(np.sum(month_lengths[0 : month - 1])) + day
 
     assert (not year_not_specified and (1 <= day_index <= 366)) or (  # noqa: S101
         year_not_specified and (1 <= day_index <= 365)


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes None
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

Currently, mypy complains about this line:

[day_index = np.sum(month_lengths[0 : month - 1]) + day](https://github.com/glamod/marine_qc/blob/main/src/marine_qc/helpers/time_control.py#L455)

**Incompatible types in assignment (expression has type "signedinteger[_64Bit]", variable has type "int")  [assignment]**

The error is due to the fact that np.sum returns a numpy integer type, which is not exactly the same as a Python int.

We can fix this by explicitly converting the result to a Python int:

```
day_index = int(np.sum(month_lengths[0 : month - 1])) + day
```

### Does this PR introduce a breaking change?
None

### Other information:
None