### PR TITLE
Standardize buoy tracking QC

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,11 +16,16 @@ New features and environments
 * add new input parameter ``marker_size`` in the plotting routines (:issue:`240`, :pull:`244`)
 * add new function to combine results from multiple QC checks into a single flag: combine_qr_results (:issue:`242`, :pull:`245`)
 * add new function that checks whether both the date and the time is valid: do_datetime_check (:pull:`246`)
+* add buoy tracking QC functions to imports in quality_control.qc_multiple_check (:issue:`249`, :pull:`250`)
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
 * Both `do_mising_value_check` and `do_missing_value_clim_check` now return `0` (pass) for numerically invalid values, otherwise `1` (fail) (:issue:`205`, :pull:`206`)
 * The minimum versions of several dependencies have been set to support Python 3.11 or higher (numpy >= 1.24.0, pandas >= 3.0.0, scipy >= 1.11.0, xarray >= v2025.07.0, xclim >= 0.56) (:pull:`224`)
+* convert buoy tracking QC outcomes from ``float`` to ``int`` (:issue:`249`, :pull:`250`)
+* implement decorator ``post_format_return_type`` into buoy tracking QC functions to convert output types to input types (:issue:`249`, :pull:`250`)
+* convert all input parameter names from the plutal into the singular in buoy tracking QC function, for instance "lats" to "lat" or "lons" to "lon" (:issue:`249`, :pull:`250`)
+* sort parameter order list in buoy tracking QC functions equivalent to other QC functions, for instance ["lon", "lat", "date"] to ["lat", "lon", "date"] (:issue:`249`, :pull:`250`)
 
 Internal changes
 ^^^^^^^^^^^^^^^^
@@ -32,6 +37,8 @@ Internal changes
 * rename plotting routines: ``latitude_longitude_plot`` to ``plot_latitude_longitude`` and ``latitude_variable_plot`` to ``plot_latitude_variable`` (:issue:`240`, :pull:`244`)
 * new helper function quality_control.qc_individual_report._do_time_check that is used in both do_time_check and do_datetime_check (:pull:`246`)
 * new helper function quality_control.qc_individual_report._do_date_check that is used in both do_date_check and do_datetime_check (:pull:`246`)
+* rename quality_control.buoy_tracking_qc into quality_control.qc_buoy_tracking (:issue:`249`, :pull:`250`)
+* move "is_monotonic" and "track_day_test" from quality_control.qc_buoy_tracking to quality_control.track_check_utils (:pull:`250`)
 
 0.3.2 (2023-04-21)
 ------------------

--- a/docs/api/api_buoy.rst
+++ b/docs/api/api_buoy.rst
@@ -19,7 +19,7 @@ Buoy tracking classes
 Buoy tracking functions
 -----------------------
 
-.. autofunction:: marine_qc.quality_control.qc_buoy_tracking_.track_day_test
+.. autofunction:: marine_qc.quality_control.qc_buoy_tracking.track_day_test
    :noindex:
 
 .. autofunction:: marine_qc.quality_control.qc_buoy_tracking.is_monotonic

--- a/docs/api/api_buoy.rst
+++ b/docs/api/api_buoy.rst
@@ -1,26 +1,26 @@
 Buoy tracking classes
 ---------------------
 
-.. autoclass:: marine_qc.quality_control.buoy_tracking_qc.SpeedChecker
+.. autoclass:: marine_qc.quality_control.qc_buoy_tracking.SpeedChecker
    :noindex:
 
-.. autoclass:: marine_qc.quality_control.buoy_tracking_qc.NewSpeedChecker
+.. autoclass:: marine_qc.quality_control.qc_buoy_tracking.NewSpeedChecker
    :noindex:
 
-.. autoclass:: marine_qc.quality_control.buoy_tracking_qc.AgroundChecker
+.. autoclass:: marine_qc.quality_control.qc_buoy_tracking.AgroundChecker
    :noindex:
 
-.. autoclass:: marine_qc.quality_control.buoy_tracking_qc.SSTTailChecker
+.. autoclass:: marine_qc.quality_control.qc_buoy_tracking.SSTTailChecker
    :noindex:
 
-.. autoclass:: marine_qc.quality_control.buoy_tracking_qc.SSTBiasedNoisyChecker
+.. autoclass:: marine_qc.quality_control.qc_buoy_tracking.SSTBiasedNoisyChecker
    :noindex:
 
 Buoy tracking functions
 -----------------------
 
-.. autofunction:: marine_qc.quality_control.buoy_tracking_qc.track_day_test
+.. autofunction:: marine_qc.quality_control.qc_buoy_tracking_.track_day_test
    :noindex:
 
-.. autofunction:: marine_qc.quality_control.buoy_tracking_qc.is_monotonic
+.. autofunction:: marine_qc.quality_control.qc_buoy_tracking.is_monotonic
    :noindex:

--- a/docs/api/api_hlp.rst
+++ b/docs/api/api_hlp.rst
@@ -70,28 +70,28 @@ Helpers in visualization module
 Static methods of buoy tracking QC classes
 ------------------------------------------
 
-.. autofunction:: marine_qc.quality_control.buoy_tracking_qc.SSTTailChecker._parse_rep
+.. autofunction:: marine_qc.quality_control.qc_buoy_tracking.SSTTailChecker._parse_rep
    :noindex:
 
-.. autofunction:: marine_qc.quality_control.buoy_tracking_qc.SSTTailChecker._preprocess_reps
+.. autofunction:: marine_qc.quality_control.qc_buoy_tracking.SSTTailChecker._preprocess_reps
    :noindex:
 
-.. autofunction:: marine_qc.quality_control.buoy_tracking_qc.SSTTailChecker._do_long_tail_check
+.. autofunction:: marine_qc.quality_control.qc_buoy_tracking.SSTTailChecker._do_long_tail_check
    :noindex:
 
-.. autofunction:: marine_qc.quality_control.buoy_tracking_qc.SSTTailChecker._do_short_tail_check
+.. autofunction:: marine_qc.quality_control.qc_buoy_tracking.SSTTailChecker._do_short_tail_check
    :noindex:
 
-.. autofunction:: marine_qc.quality_control.buoy_tracking_qc.SSTBiasedNoisyChecker._parse_rep
+.. autofunction:: marine_qc.quality_control.qc_buoy_tracking.SSTBiasedNoisyChecker._parse_rep
    :noindex:
 
-.. autofunction:: marine_qc.quality_control.buoy_tracking_qc.SSTBiasedNoisyChecker._preprocess_reps
+.. autofunction:: marine_qc.quality_control.qc_buoy_tracking.SSTBiasedNoisyChecker._preprocess_reps
    :noindex:
 
-.. autofunction:: marine_qc.quality_control.buoy_tracking_qc.SSTBiasedNoisyChecker._long_record_qc
+.. autofunction:: marine_qc.quality_control.qc_buoy_tracking.SSTBiasedNoisyChecker._long_record_qc
    :noindex:
 
-.. autofunction:: marine_qc.quality_control.buoy_tracking_qc.SSTBiasedNoisyChecker._short_record_qc
+.. autofunction:: marine_qc.quality_control.qc_buoy_tracking.SSTBiasedNoisyChecker._short_record_qc
    :noindex:
 
 Internal data type aliases

--- a/src/marine_qc/quality_control/__init__.py
+++ b/src/marine_qc/quality_control/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .buoy_tracking_qc import (
+from .qc_buoy_tracking import (
     do_aground_check,
     do_new_aground_check,
     do_new_speed_check,

--- a/src/marine_qc/quality_control/qc_buoy_tracking.py
+++ b/src/marine_qc/quality_control/qc_buoy_tracking.py
@@ -1739,8 +1739,8 @@ class SSTBiasedNoisyChecker:
 @post_format_return_type(["lat"])
 @inspect_arrays(["lon", "lat", "date"])
 def do_speed_check(
-    lon: SequenceNumberType,
     lat: SequenceNumberType,
+    lon: SequenceNumberType,
     date: SequenceDatetimeType,
     speed_limit: float,
     min_win_period: float,
@@ -1751,10 +1751,10 @@ def do_speed_check(
 
     Parameters
     ----------
-    lon : :py:obj:`~marine_qc.SequenceNumberType`
-        1-dimensional longitude array in degrees.
     lat : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional latitude array in degrees.
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
+        1-dimensional longitude array in degrees.
     date : :py:obj:`~marine_qc.SequenceDatetimeType`
         1-dimensional date array.
     speed_limit : float
@@ -1796,8 +1796,8 @@ def do_speed_check(
 @post_format_return_type(["lat"])
 @inspect_arrays(["lon", "lat", "date"])
 def do_new_speed_check(
-    lon: SequenceNumberType,
     lat: SequenceNumberType,
+    lon: SequenceNumberType,
     date: SequenceDatetimeType,
     speed_limit: float,
     min_win_period: float,
@@ -1811,10 +1811,10 @@ def do_new_speed_check(
 
     Parameters
     ----------
-    lon : :py:obj:`~marine_qc.SequenceNumberType`
-        1-dimensional longitude array in degrees.
     lat : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional latitude array in degrees.
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
+        1-dimensional longitude array in degrees.
     date : :py:obj:`~marine_qc.SequenceDatetimeType`
         1-dimensional date array.
     speed_limit : float
@@ -1874,10 +1874,10 @@ def do_new_speed_check(
 
 
 @post_format_return_type(["lat"])
-@inspect_arrays(["lon", "lat", "date"])
+@inspect_arrays(["lat", "lon", "date"])
 def do_aground_check(
-    lon: SequenceNumberType,
     lat: SequenceNumberType,
+    lon: SequenceNumberType,
     date: SequenceDatetimeType,
     smooth_win: int,
     min_win_period: int,
@@ -1888,10 +1888,10 @@ def do_aground_check(
 
     Parameters
     ----------
-    lon : :py:obj:`~marine_qc.SequenceNumberType`
-        1-dimensional longitude array in degrees.
     lat : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional latitude array in degrees.
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
+        1-dimensional longitude array in degrees.
     date : :py:obj:`~marine_qc.SequenceDatetimeType`
         1-dimensional date array.
     smooth_win : int
@@ -1932,8 +1932,8 @@ def do_aground_check(
 @post_format_return_type(["lat"])
 @inspect_arrays(["lon", "lat", "date"])
 def do_new_aground_check(
-    lon: SequenceNumberType,
     lat: SequenceNumberType,
+    lon: SequenceNumberType,
     date: SequenceDatetimeType,
     smooth_win: int,
     min_win_period: int,
@@ -1943,10 +1943,10 @@ def do_new_aground_check(
 
     Parameters
     ----------
-    lon : :py:obj:`~marine_qc.SequenceNumberType`
-        1-dimensional longitude array in degrees.
     lat : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional latitude array in degrees.
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
+        1-dimensional longitude array in degrees.
     date : :py:obj:`~marine_qc.SequenceDatetimeType`
         1-dimensional date array.
     smooth_win : int
@@ -1982,8 +1982,8 @@ def do_new_aground_check(
 @post_format_return_type(["lat"])
 @inspect_arrays(["lat", "lon", "sst", "ostia", "ice", "bgvar", "date"])
 def do_sst_start_tail_check(
-    lon: SequenceNumberType,
     lat: SequenceNumberType,
+    lon: SequenceNumberType,
     date: SequenceDatetimeType,
     sst: SequenceNumberType,
     ostia: SequenceNumberType,
@@ -2003,10 +2003,10 @@ def do_sst_start_tail_check(
 
     Parameters
     ----------
-    lon : :py:obj:`~marine_qc.SequenceNumberType`
-        1-dimensional longitude array in degrees.
     lat : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional latitude array in degrees.
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
+        1-dimensional longitude array in degrees.
     date : :py:obj:`~marine_qc.SequenceDatetimeType`
         1-dimensional date array.
     sst : :py:obj:`~marine_qc.SequenceNumberType`
@@ -2090,8 +2090,8 @@ def do_sst_start_tail_check(
 @post_format_return_type(["lat"])
 @inspect_arrays(["lat", "lon", "sst", "ostia", "ice", "bgvar", "date"])
 def do_sst_end_tail_check(
-    lon: SequenceNumberType,
     lat: SequenceNumberType,
+    lon: SequenceNumberType,
     date: SequenceDatetimeType,
     sst: SequenceNumberType,
     ostia: SequenceNumberType,
@@ -2111,10 +2111,10 @@ def do_sst_end_tail_check(
 
     Parameters
     ----------
-    lon : :py:obj:`~marine_qc.SequenceNumberType`
-        1-dimensional longitude array in degrees.
     lat : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional latitude array in degrees.
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
+        1-dimensional longitude array in degrees.
     date : :py:obj:`~marine_qc.SequenceDatetimeType`
         1-dimensional date array.
     sst : :py:obj:`~marine_qc.SequenceNumberType`
@@ -2198,8 +2198,8 @@ def do_sst_end_tail_check(
 @post_format_return_type(["lat"])
 @inspect_arrays(["lat", "lon", "date", "sst", "ostia", "bgvar", "ice"])
 def do_sst_biased_check(
-    lon: SequenceNumberType,
     lat: SequenceNumberType,
+    lon: SequenceNumberType,
     date: SequenceDatetimeType,
     sst: SequenceNumberType,
     ostia: SequenceNumberType,
@@ -2218,10 +2218,10 @@ def do_sst_biased_check(
 
     Parameters
     ----------
-    lon : :py:obj:`~marine_qc.SequenceNumberType`
-        1-dimensional longitude array in degrees.
     lat : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional latitude array in degrees.
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
+        1-dimensional longitude array in degrees.
     date : :py:obj:`~marine_qc.SequenceDatetimeType`
         1-dimensional date array.
     sst : :py:obj:`~marine_qc.SequenceNumberType`
@@ -2298,8 +2298,8 @@ def do_sst_biased_check(
 @post_format_return_type(["lat"])
 @inspect_arrays(["lat", "lon", "date", "sst", "ostia", "bgvar", "ice"])
 def do_sst_noisy_check(
-    lon: SequenceNumberType,
     lat: SequenceNumberType,
+    lon: SequenceNumberType,
     date: SequenceDatetimeType,
     sst: SequenceNumberType,
     ostia: SequenceNumberType,
@@ -2318,10 +2318,10 @@ def do_sst_noisy_check(
 
     Parameters
     ----------
-    lon : :py:obj:`~marine_qc.SequenceNumberType`
-        1-dimensional longitude array in degrees.
     lat : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional latitude array in degrees.
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
+        1-dimensional longitude array in degrees.
     date : :py:obj:`~marine_qc.SequenceDatetimeType`
         1-dimensional date array.
     sst : :py:obj:`~marine_qc.SequenceNumberType`
@@ -2398,8 +2398,8 @@ def do_sst_noisy_check(
 @post_format_return_type(["lat"])
 @inspect_arrays(["lat", "lon", "date", "sst", "ostia", "bgvar", "ice"])
 def do_sst_biased_noisy_short_check(
-    lon: SequenceNumberType,
     lat: SequenceNumberType,
+    lon: SequenceNumberType,
     date: SequenceDatetimeType,
     sst: SequenceNumberType,
     ostia: SequenceNumberType,
@@ -2418,10 +2418,10 @@ def do_sst_biased_noisy_short_check(
 
     Parameters
     ----------
-    lon : :py:obj:`~marine_qc.SequenceNumberType`
-        1-dimensional longitude array in degrees.
     lat : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional latitude array in degrees.
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
+        1-dimensional longitude array in degrees.
     date : :py:obj:`~marine_qc.SequenceDatetimeType`
         1-dimensional date array.
     sst : :py:obj:`~marine_qc.SequenceNumberType`

--- a/src/marine_qc/quality_control/qc_buoy_tracking.py
+++ b/src/marine_qc/quality_control/qc_buoy_tracking.py
@@ -181,11 +181,11 @@ class SpeedChecker:
 
     Parameters
     ----------
-    lons : :py:obj:`~marine_qc.SequenceNumberType`
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
             1-dimensional longitude array in degrees.
-    lats : :py:obj:`~marine_qc.SequenceNumberType`
+    lat : :py:obj:`~marine_qc.SequenceNumberType`
             1-dimensional latitude array in degrees.
-    dates : :py:obj:`~marine_qc.SequenceDatetimeType`
+    date : :py:obj:`~marine_qc.SequenceDatetimeType`
             1-dimensional date array.
     speed_limit : float
             Maximum allowable speed for an in situ drifting buoy (metres per second).
@@ -200,9 +200,9 @@ class SpeedChecker:
 
     def __init__(
         self,
-        lons: SequenceNumberType,
-        lats: SequenceNumberType,
-        dates: SequenceDatetimeType,
+        lon: SequenceNumberType,
+        lat: SequenceNumberType,
+        date: SequenceDatetimeType,
         speed_limit: float,
         min_win_period: float,
         max_win_period: float,
@@ -212,11 +212,11 @@ class SpeedChecker:
 
         Parameters
         ----------
-        lons : :py:obj:`~marine_qc.SequenceNumberType`
+        lon : :py:obj:`~marine_qc.SequenceNumberType`
             1-dimensional longitude array in degrees.
-        lats : :py:obj:`~marine_qc.SequenceNumberType`
+        lat : :py:obj:`~marine_qc.SequenceNumberType`
             1-dimensional latitude array in degrees.
-        dates : :py:obj:`~marine_qc.SequenceDatetimeType`
+        date : :py:obj:`~marine_qc.SequenceDatetimeType`
             1-dimensional date array.
         speed_limit : float
             Maximum allowable speed for an in situ drifting buoy (metres per second).
@@ -228,19 +228,19 @@ class SpeedChecker:
             (this should be greater than min_win_period and allow for some erratic temporal sampling e.g.
             min_win_period + 0.2 to allow for gaps of up to 0.2 - days in sampling).
         """
-        self.lon = np.asarray(lons, dtype=float)
-        self.lat = np.asarray(lats, dtype=float)
-        self.nreps = len(lons)
+        self.lon = np.asarray(lon, dtype=float)
+        self.lat = np.asarray(lat, dtype=float)
+        self.nreps = len(lon)
 
-        dates_list: list[datetime] = pd.to_datetime(dates).tolist()
-        self.hrs = np.asarray(convert_date_to_hours(dates_list), dtype=float)
+        date_list: list[datetime] = pd.to_datetime(date).tolist()
+        self.hrs = np.asarray(convert_date_to_hours(date_list), dtype=float)
 
         self.speed_limit = speed_limit
         self.min_win_period = min_win_period
         self.max_win_period = max_win_period
 
         # Initialise QC outcomes with untested
-        self.qc_outcomes = np.zeros(self.nreps, dtype=float) + untested
+        self.qc_outcomes = np.zeros(self.nreps, dtype=int) + untested
 
     def get_qc_outcomes(self) -> np.ndarray:
         """
@@ -399,11 +399,11 @@ class NewSpeedChecker:
 
     Parameters
     ----------
-    lons : :py:obj:`~marine_qc.SequenceNumberType`
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
             1-dimensional longitude array in degrees.
-    lats : :py:obj:`~marine_qc.SequenceNumberType`
+    lat : :py:obj:`~marine_qc.SequenceNumberType`
             1-dimensional latitude array in degrees.
-    dates : :py:obj:`~marine_qc.SequenceDatetimeType`
+    date : :py:obj:`~marine_qc.SequenceDatetimeType`
             1-dimensional date array.
     speed_limit : float
             Maximum allowable speed for an in situ drifting buoy (metres per second).
@@ -423,9 +423,9 @@ class NewSpeedChecker:
 
     def __init__(
         self,
-        lons: SequenceNumberType,
-        lats: SequenceNumberType,
-        dates: SequenceDatetimeType,
+        lon: SequenceNumberType,
+        lat: SequenceNumberType,
+        date: SequenceDatetimeType,
         speed_limit: float,
         min_win_period: float,
         ship_speed_limit: float,
@@ -438,11 +438,11 @@ class NewSpeedChecker:
 
         Parameters
         ----------
-        lons : :py:obj:`~marine_qc.SequenceNumberType`
+        lon : :py:obj:`~marine_qc.SequenceNumberType`
             1-dimensional longitude array in degrees.
-        lats : :py:obj:`~marine_qc.SequenceNumberType`
+        lat : :py:obj:`~marine_qc.SequenceNumberType`
             1-dimensional latitude array in degrees.
-        dates : :py:obj:`~marine_qc.SequenceDatetimeType`
+        date : :py:obj:`~marine_qc.SequenceDatetimeType`
             1-dimensional date array.
         speed_limit : float
             Maximum allowable speed for an in situ drifting buoy (metres per second).
@@ -460,13 +460,13 @@ class NewSpeedChecker:
         n_neighbours : int
             Number of neighbours considered in the IQUAM track check.
         """
-        self.lon = np.asarray(lons, dtype=float)
-        self.lat = np.asarray(lats, dtype=float)
-        self.nreps = len(lons)
-        self.dates = np.asarray(dates, dtype=datetime)
+        self.lon = np.asarray(lon, dtype=float)
+        self.lat = np.asarray(lat, dtype=float)
+        self.nreps = len(lon)
+        self.date = np.asarray(date, dtype=datetime)
 
-        dates_list: list[datetime] = pd.to_datetime(dates).tolist()
-        self.hrs = np.asarray(convert_date_to_hours(dates_list), dtype=float)
+        date_list: list[datetime] = pd.to_datetime(date).tolist()
+        self.hrs = np.asarray(convert_date_to_hours(date_list), dtype=float)
 
         self.speed_limit = speed_limit
         self.min_win_period = min_win_period
@@ -479,7 +479,7 @@ class NewSpeedChecker:
         self.iquam_track_ship: np.ndarray = np.array([], dtype=int)
 
         # Initialise QC outcomes with untested
-        self.qc_outcomes = np.zeros(self.nreps) + untested
+        self.qc_outcomes = np.zeros(self.nreps, dtype=int) + untested
 
     def get_qc_outcomes(self) -> np.ndarray:
         """
@@ -557,7 +557,7 @@ class NewSpeedChecker:
         self.iquam_track_ship = do_iquam_track_check(
             self.lat,
             self.lon,
-            self.dates,
+            self.date,
             self.ship_speed_limit,
             self.delta_d,
             self.delta_t,
@@ -576,7 +576,7 @@ class NewSpeedChecker:
         self.perform_iquam_track_check()
 
         # Initialise
-        self.qc_outcomes = np.zeros(nrep) + passed
+        self.qc_outcomes = np.zeros(nrep, dtype=int) + passed
 
         # loop through timeseries to see if drifter is moving too fast and flag any occurrences
         index_arr = np.array(range(0, nrep))  # type: np.ndarray
@@ -637,11 +637,11 @@ class AgroundChecker:
 
     Parameters
     ----------
-    lons : :py:obj:`~marine_qc.SequenceNumberType`
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
             1-dimensional longitude array in degrees.
-    lats : :py:obj:`~marine_qc.SequenceNumberType`
+    lat : :py:obj:`~marine_qc.SequenceNumberType`
             1-dimensional latitude array in degrees.
-    dates : :py:obj:`~marine_qc.SequenceDatetimeType`
+    date : :py:obj:`~marine_qc.SequenceDatetimeType`
             1-dimensional date array.
     smooth_win : int
             Length of window (odd number) in datapoints used for smoothing lon/lat.
@@ -658,9 +658,9 @@ class AgroundChecker:
 
     def __init__(
         self,
-        lons: SequenceNumberType,
-        lats: SequenceNumberType,
-        dates: SequenceDatetimeType,
+        lon: SequenceNumberType,
+        lat: SequenceNumberType,
+        date: SequenceDatetimeType,
         smooth_win: int,
         min_win_period: int,
         max_win_period: int | None,
@@ -670,11 +670,11 @@ class AgroundChecker:
 
         Parameters
         ----------
-        lons : :py:obj:`~marine_qc.SequenceNumberType`
+        lon : :py:obj:`~marine_qc.SequenceNumberType`
             1-dimensional longitude array in degrees.
-        lats : :py:obj:`~marine_qc.SequenceNumberType`
+        lat : :py:obj:`~marine_qc.SequenceNumberType`
             1-dimensional latitude array in degrees.
-        dates : :py:obj:`~marine_qc.SequenceDatetimeType`
+        date : :py:obj:`~marine_qc.SequenceDatetimeType`
             1-dimensional date array.
         smooth_win : int
             Length of window (odd number) in datapoints used for smoothing lon/lat.
@@ -685,12 +685,12 @@ class AgroundChecker:
             than min_win_period and allow for erratic temporal sampling e.g. min_win_period+2 to allow for gaps of
             up to 2-days in sampling).
         """
-        self.lon = np.asarray(lons, dtype=float)
-        self.lat = np.asarray(lats, dtype=float)
-        self.nreps = len(lons)
+        self.lon = np.asarray(lon, dtype=float)
+        self.lat = np.asarray(lat, dtype=float)
+        self.nreps = len(lon)
 
-        dates_list: list[datetime] = pd.to_datetime(dates).tolist()
-        self.hrs = np.asarray(convert_date_to_hours(dates_list), dtype=float)
+        date_list: list[datetime] = pd.to_datetime(date).tolist()
+        self.hrs = np.asarray(convert_date_to_hours(date_list), dtype=float)
 
         self.smooth_win = smooth_win
         self.min_win_period = min_win_period
@@ -701,7 +701,7 @@ class AgroundChecker:
         self.hrs_smooth: np.ndarray = np.array([], dtype=float)
 
         # Initialise QC outcomes with untested
-        self.qc_outcomes = np.zeros(self.nreps) + untested
+        self.qc_outcomes = np.zeros(self.nreps, dtype=int) + untested
 
     def get_qc_outcomes(self) -> np.ndarray:
         """
@@ -898,7 +898,7 @@ class SSTTailChecker:
             1-dimensional array of ice concentrations in the range 0.0 to 1.0.
     bgvar : :py:obj:`~marine_qc.SequenceNumberType`
             1-dimensional array of background sea surface temperature fields variances in K^2.
-    dates : :py:obj:`~marine_qc.SequenceDatetimeType`
+    date : :py:obj:`~marine_qc.SequenceDatetimeType`
             1-dimensional date array.
     long_win_len : int
             Length of window (in data-points) over which to make long tail-check (must be an odd number).
@@ -929,7 +929,7 @@ class SSTTailChecker:
         ostia: SequenceNumberType,
         ice: SequenceNumberType,
         bgvar: SequenceNumberType,
-        dates: SequenceDatetimeType,
+        date: SequenceDatetimeType,
         long_win_len: int,
         long_err_std_n: float,
         short_win_len: int,
@@ -956,7 +956,7 @@ class SSTTailChecker:
             1-dimensional array of ice concentrations in the range 0.0 to 1.0.
         bgvar : :py:obj:`~marine_qc.SequenceNumberType`
             1-dimensional array of background sea surface temperature fields variances in K^2.
-        dates : :py:obj:`~marine_qc.SequenceDatetimeType`
+        date : :py:obj:`~marine_qc.SequenceDatetimeType`
             1-dimensional date array.
         long_win_len : int
             Length of window (in data-points) over which to make long tail-check (must be an odd number).
@@ -987,10 +987,10 @@ class SSTTailChecker:
         self.ostia = np.asarray(ostia, dtype=float)
         self.ice = np.asarray(ice, dtype=float)
         self.bgvar = np.asarray(bgvar, dtype=float)
-        self.dates = np.asarray(dates, dtype=datetime)
+        self.date = np.asarray(date, dtype=datetime)
 
-        dates_list: list[datetime] = pd.to_datetime(dates).tolist()
-        self.hrs = np.asarray(convert_date_to_hours(dates_list), dtype=float)
+        date_list: list[datetime] = pd.to_datetime(date).tolist()
+        self.hrs = np.asarray(convert_date_to_hours(date_list), dtype=float)
 
         self.reps_ind: np.ndarray = np.array([], dtype=float)
         self.sst_anom: np.ndarray = np.array([], dtype=float)
@@ -999,7 +999,7 @@ class SSTTailChecker:
         self.start_tail_ind: int
         self.end_tail_ind: int
 
-        self.qc_outcomes = np.zeros(self.nreps) + untested
+        self.qc_outcomes = np.zeros(self.nreps, dtype=int) + untested
 
         self.long_win_len = long_win_len
         self.long_err_std_n = long_err_std_n
@@ -1120,7 +1120,7 @@ class SSTTailChecker:
         ostia: float,
         ice: float,
         bgvar: float,
-        dates: datetime,
+        date: datetime,
     ) -> tuple[float, float, float, bool, bool]:
         """
         Process a report.
@@ -1137,7 +1137,7 @@ class SSTTailChecker:
             Ice concentration value matched to this observation.
         bgvar : float
             Background variance value matched to this observation.
-        dates : datetime.datetime
+        date : datetime.datetime
             Date and time of the observation.
 
         Returns
@@ -1156,10 +1156,10 @@ class SSTTailChecker:
 
         try:
             daytime = track_day_test(
-                dates.year,
-                dates.month,
-                dates.day,
-                dates.hour + dates.minute / 60,
+                date.year,
+                date.month,
+                date.day,
+                date.hour + date.minute / 60,
                 lat,
                 lon,
                 -2.5,
@@ -1198,7 +1198,7 @@ class SSTTailChecker:
                 self.ostia[ind],
                 self.ice[ind],
                 self.bgvar[ind],
-                self.dates[ind],
+                self.date[ind],
             )
             if invalid_ob:
                 invalid_series = True
@@ -1357,7 +1357,7 @@ class SSTBiasedNoisyChecker:
             1-dimensional latitude array in degrees.
     lon : :py:obj:`~marine_qc.SequenceNumberType`
             1-dimensional longitude array in degrees.
-    dates : :py:obj:`~marine_qc.SequenceDatetimeType`
+    date : :py:obj:`~marine_qc.SequenceDatetimeType`
             1-dimensional date array.
     sst : :py:obj:`~marine_qc.SequenceNumberType`
             1-dimensional sea surface temperature array in K.
@@ -1388,7 +1388,7 @@ class SSTBiasedNoisyChecker:
         self,
         lat: SequenceNumberType,
         lon: SequenceNumberType,
-        dates: SequenceDatetimeType,
+        date: SequenceDatetimeType,
         sst: SequenceNumberType,
         ostia: SequenceNumberType,
         bgvar: SequenceNumberType,
@@ -1410,7 +1410,7 @@ class SSTBiasedNoisyChecker:
             1-dimensional latitude array in degrees.
         lon : :py:obj:`~marine_qc.SequenceNumberType`
             1-dimensional longitude array in degrees.
-        dates : :py:obj:`~marine_qc.SequenceDatetimeType`
+        date : :py:obj:`~marine_qc.SequenceDatetimeType`
             1-dimensional date array.
         sst : :py:obj:`~marine_qc.SequenceNumberType`
             1-dimensional sea surface temperature array in K.
@@ -1438,7 +1438,7 @@ class SSTBiasedNoisyChecker:
         """
         self.lat = np.asarray(lat, dtype=float)
         self.lon = np.asarray(lon, dtype=float)
-        self.dates = np.asarray(dates, dtype=datetime)
+        self.date = np.asarray(date, dtype=datetime)
         self.sst = np.asarray(sst, dtype=float)
         self.ostia = np.asarray(ostia, dtype=float)
         self.bgvar = np.asarray(bgvar, dtype=float)
@@ -1446,8 +1446,8 @@ class SSTBiasedNoisyChecker:
 
         self.nreps = len(lat)
 
-        dates_list: list[datetime] = pd.to_datetime(dates).tolist()
-        self.hrs = np.asarray(convert_date_to_hours(dates_list), dtype=float)
+        date_list: list[datetime] = pd.to_datetime(date).tolist()
+        self.hrs = np.asarray(convert_date_to_hours(date_list), dtype=float)
 
         self.n_eval = n_eval
         self.bias_lim = bias_lim
@@ -1461,9 +1461,9 @@ class SSTBiasedNoisyChecker:
         self.bgerr: np.ndarray = np.array([], dtype=float)
         self.bgvar_is_masked: bool
 
-        self.qc_outcomes_bias = np.zeros(self.nreps) + untested
-        self.qc_outcomes_noise = np.zeros(self.nreps) + untested
-        self.qc_outcomes_short = np.zeros(self.nreps) + untested
+        self.qc_outcomes_bias = np.zeros(self.nreps, dtype=int) + untested
+        self.qc_outcomes_noise = np.zeros(self.nreps, dtype=int) + untested
+        self.qc_outcomes_short = np.zeros(self.nreps, dtype=int) + untested
 
     def valid_parameters(self) -> bool:
         """
@@ -1575,7 +1575,7 @@ class SSTBiasedNoisyChecker:
         ostia: float,
         ice: float,
         bgvar: float,
-        dates: datetime,
+        date: datetime,
         background_err_lim: float,
     ) -> tuple[float, float, float, bool, bool, bool]:
         """
@@ -1593,7 +1593,7 @@ class SSTBiasedNoisyChecker:
             Ice concentration field value.
         bgvar : float
             Background variance field value.
-        dates : datetime
+        date : datetime
             Date and time of the observation to be parsed.
         background_err_lim : float
             Background error variance beyond which the SST background is deemed unreliable (degC squared or K squared).
@@ -1615,10 +1615,10 @@ class SSTBiasedNoisyChecker:
 
         try:
             daytime = track_day_test(
-                dates.year,
-                dates.month,
-                dates.day,
-                dates.hour + dates.minute / 60,
+                date.year,
+                date.month,
+                date.day,
+                date.hour + date.minute / 60,
                 lat,
                 lon,
                 -2.5,
@@ -1664,7 +1664,7 @@ class SSTBiasedNoisyChecker:
                 self.ostia[ind],
                 self.ice[ind],
                 self.bgvar[ind],
-                self.dates[ind],
+                self.date[ind],
                 self.background_err_lim,
             )
             if invalid_ob:
@@ -1725,11 +1725,11 @@ class SSTBiasedNoisyChecker:
             self.qc_outcomes_short[:] = failed
 
 
-@inspect_arrays(["lons", "lats", "dates"])
+@inspect_arrays(["lon", "lat", "date"])
 def do_speed_check(
-    lons: SequenceNumberType,
-    lats: SequenceNumberType,
-    dates: SequenceDatetimeType,
+    lon: SequenceNumberType,
+    lat: SequenceNumberType,
+    date: SequenceDatetimeType,
     speed_limit: float,
     min_win_period: float,
     max_win_period: float,
@@ -1739,11 +1739,11 @@ def do_speed_check(
 
     Parameters
     ----------
-    lons : :py:obj:`~marine_qc.SequenceNumberType`
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional longitude array in degrees.
-    lats : :py:obj:`~marine_qc.SequenceNumberType`
+    lat : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional latitude array in degrees.
-    dates : :py:obj:`~marine_qc.SequenceDatetimeType`
+    date : :py:obj:`~marine_qc.SequenceDatetimeType`
         1-dimensional date array.
     speed_limit : float
         Maximum allowable speed for an in situ drifting buoy (metres per second).
@@ -1774,18 +1774,18 @@ def do_speed_check(
     * min_win_period = 0.8
     * max_win_perido = 1.8
     """
-    lons_arr, lats_arr, dates_arr = ensure_arrays(lons=lons, lats=lats, dates=dates)
+    lon_arr, lat_arr, date_arr = ensure_arrays(lon=lon, lat=lat, date=date)
 
-    checker = SpeedChecker(lons_arr, lats_arr, dates_arr, speed_limit, min_win_period, max_win_period)
+    checker = SpeedChecker(lon_arr, lat_arr, date_arr, speed_limit, min_win_period, max_win_period)
     checker.do_speed_check()
     return checker.get_qc_outcomes()
 
 
-@inspect_arrays(["lons", "lats", "dates"])
+@inspect_arrays(["lon", "lat", "date"])
 def do_new_speed_check(
-    lons: SequenceNumberType,
-    lats: SequenceNumberType,
-    dates: SequenceDatetimeType,
+    lon: SequenceNumberType,
+    lat: SequenceNumberType,
+    date: SequenceDatetimeType,
     speed_limit: float,
     min_win_period: float,
     ship_speed_limit: float,
@@ -1798,11 +1798,11 @@ def do_new_speed_check(
 
     Parameters
     ----------
-    lons : :py:obj:`~marine_qc.SequenceNumberType`
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional longitude array in degrees.
-    lats : :py:obj:`~marine_qc.SequenceNumberType`
+    lat : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional latitude array in degrees.
-    dates : :py:obj:`~marine_qc.SequenceDatetimeType`
+    date : :py:obj:`~marine_qc.SequenceDatetimeType`
         1-dimensional date array.
     speed_limit : float
         Maximum allowable speed for an in situ drifting buoy (metres per second).
@@ -1843,12 +1843,12 @@ def do_new_speed_check(
     * delta_t = 0.01
     * n_neighbours = 5
     """
-    lons_arr, lats_arr, dates_arr = ensure_arrays(lons=lons, lats=lats, dates=dates)
+    lon_arr, lat_arr, date_arr = ensure_arrays(lon=lon, lat=lat, date=date)
 
     checker = NewSpeedChecker(
-        lons_arr,
-        lats_arr,
-        dates_arr,
+        lon_arr,
+        lat_arr,
+        date_arr,
         speed_limit,
         min_win_period,
         ship_speed_limit,
@@ -1860,11 +1860,11 @@ def do_new_speed_check(
     return checker.get_qc_outcomes()
 
 
-@inspect_arrays(["lons", "lats", "dates"])
+@inspect_arrays(["lon", "lat", "date"])
 def do_aground_check(
-    lons: SequenceNumberType,
-    lats: SequenceNumberType,
-    dates: SequenceDatetimeType,
+    lon: SequenceNumberType,
+    lat: SequenceNumberType,
+    date: SequenceDatetimeType,
     smooth_win: int,
     min_win_period: int,
     max_win_period: int,
@@ -1874,11 +1874,11 @@ def do_aground_check(
 
     Parameters
     ----------
-    lons : :py:obj:`~marine_qc.SequenceNumberType`
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional longitude array in degrees.
-    lats : :py:obj:`~marine_qc.SequenceNumberType`
+    lat : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional latitude array in degrees.
-    dates : :py:obj:`~marine_qc.SequenceDatetimeType`
+    date : :py:obj:`~marine_qc.SequenceDatetimeType`
         1-dimensional date array.
     smooth_win : int
         Length of window (odd number) in datapoints used for smoothing lon/lat.
@@ -1908,18 +1908,18 @@ def do_aground_check(
     * min_win_period = 8
     * max_win_period = 10
     """
-    lats_arr, lons_arr, dates_arr = ensure_arrays(lats=lats, lons=lons, dates=dates)
+    lat_arr, lon_arr, date_arr = ensure_arrays(lat=lat, lon=lon, date=date)
 
-    checker = AgroundChecker(lons_arr, lats_arr, dates_arr, smooth_win, min_win_period, max_win_period)
+    checker = AgroundChecker(lon_arr, lat_arr, date_arr, smooth_win, min_win_period, max_win_period)
     checker.do_aground_check()
     return checker.get_qc_outcomes()
 
 
-@inspect_arrays(["lons", "lats", "dates"])
+@inspect_arrays(["lon", "lat", "date"])
 def do_new_aground_check(
-    lons: SequenceNumberType,
-    lats: SequenceNumberType,
-    dates: SequenceDatetimeType,
+    lon: SequenceNumberType,
+    lat: SequenceNumberType,
+    date: SequenceDatetimeType,
     smooth_win: int,
     min_win_period: int,
 ) -> np.ndarray:
@@ -1928,11 +1928,11 @@ def do_new_aground_check(
 
     Parameters
     ----------
-    lons : :py:obj:`~marine_qc.SequenceNumberType`
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional longitude array in degrees.
-    lats : :py:obj:`~marine_qc.SequenceNumberType`
+    lat : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional latitude array in degrees.
-    dates : :py:obj:`~marine_qc.SequenceDatetimeType`
+    date : :py:obj:`~marine_qc.SequenceDatetimeType`
         1-dimensional date array.
     smooth_win : int
         Length of window (odd number) in datapoints used for smoothing lon/lat.
@@ -1957,18 +1957,18 @@ def do_new_aground_check(
     * smooth_win = 41
     * min_win_period = 8
     """
-    lats_arr, lons_arr, dates_arr = ensure_arrays(lats=lats, lons=lons, dates=dates)
+    lat_arr, lon_arr, date_arr = ensure_arrays(lat=lat, lon=lon, date=date)
 
-    checker = AgroundChecker(lons_arr, lats_arr, dates_arr, smooth_win, min_win_period, None)
+    checker = AgroundChecker(lon_arr, lat_arr, date_arr, smooth_win, min_win_period, None)
     checker.do_aground_check()
     return checker.get_qc_outcomes()
 
 
-@inspect_arrays(["lats", "lons", "sst", "ostia", "ice", "bgvar", "dates"])
+@inspect_arrays(["lat", "lon", "sst", "ostia", "ice", "bgvar", "date"])
 def do_sst_start_tail_check(
-    lons: SequenceNumberType,
-    lats: SequenceNumberType,
-    dates: SequenceDatetimeType,
+    lon: SequenceNumberType,
+    lat: SequenceNumberType,
+    date: SequenceDatetimeType,
     sst: SequenceNumberType,
     ostia: SequenceNumberType,
     ice: SequenceNumberType,
@@ -1987,11 +1987,11 @@ def do_sst_start_tail_check(
 
     Parameters
     ----------
-    lons : :py:obj:`~marine_qc.SequenceNumberType`
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional longitude array in degrees.
-    lats : :py:obj:`~marine_qc.SequenceNumberType`
+    lat : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional latitude array in degrees.
-    dates : :py:obj:`~marine_qc.SequenceDatetimeType`
+    date : :py:obj:`~marine_qc.SequenceDatetimeType`
         1-dimensional date array.
     sst : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional array of sea surface temperatures in K.
@@ -2046,18 +2046,18 @@ def do_sst_start_tail_check(
     * drif_intra = 1.00
     * background_err_lim = 0.3
     """
-    lats_arr, lons_arr, sst_arr, ostia_arr, ice_arr, bgvar_arr, dates_arr = ensure_arrays(
-        lats=lats, lons=lons, sst=sst, ostia=ostia, ice=ice, bgvar=bgvar, dates=dates
+    lat_arr, lon_arr, sst_arr, ostia_arr, ice_arr, bgvar_arr, date_arr = ensure_arrays(
+        lat=lat, lon=lon, sst=sst, ostia=ostia, ice=ice, bgvar=bgvar, date=date
     )
 
     checker = SSTTailChecker(
-        lats_arr,
-        lons_arr,
+        lat_arr,
+        lon_arr,
         sst_arr,
         ostia_arr,
         ice_arr,
         bgvar_arr,
-        dates_arr,
+        date_arr,
         long_win_len,
         long_err_std_n,
         short_win_len,
@@ -2071,11 +2071,11 @@ def do_sst_start_tail_check(
     return checker.get_qc_outcomes()
 
 
-@inspect_arrays(["lats", "lons", "sst", "ostia", "ice", "bgvar", "dates"])
+@inspect_arrays(["lat", "lon", "sst", "ostia", "ice", "bgvar", "date"])
 def do_sst_end_tail_check(
-    lons: SequenceNumberType,
-    lats: SequenceNumberType,
-    dates: SequenceDatetimeType,
+    lon: SequenceNumberType,
+    lat: SequenceNumberType,
+    date: SequenceDatetimeType,
     sst: SequenceNumberType,
     ostia: SequenceNumberType,
     ice: SequenceNumberType,
@@ -2094,11 +2094,11 @@ def do_sst_end_tail_check(
 
     Parameters
     ----------
-    lons : :py:obj:`~marine_qc.SequenceNumberType`
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional longitude array in degrees.
-    lats : :py:obj:`~marine_qc.SequenceNumberType`
+    lat : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional latitude array in degrees.
-    dates : :py:obj:`~marine_qc.SequenceDatetimeType`
+    date : :py:obj:`~marine_qc.SequenceDatetimeType`
         1-dimensional date array.
     sst : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional array of sea surface temperatures in K.
@@ -2153,18 +2153,18 @@ def do_sst_end_tail_check(
     * drif_intra = 1.00
     * background_err_lim = 0.3
     """
-    lats_arr, lons_arr, sst_arr, ostia_arr, ice_arr, bgvar_arr, dates_arr = ensure_arrays(
-        lats=lats, lons=lons, sst=sst, ostia=ostia, ice=ice, bgvar=bgvar, dates=dates
+    lat_arr, lon_arr, sst_arr, ostia_arr, ice_arr, bgvar_arr, date_arr = ensure_arrays(
+        lat=lat, lon=lon, sst=sst, ostia=ostia, ice=ice, bgvar=bgvar, date=date
     )
 
     checker = SSTTailChecker(
-        lats_arr,
-        lons_arr,
+        lat_arr,
+        lon_arr,
         sst_arr,
         ostia_arr,
         ice_arr,
         bgvar_arr,
-        dates_arr,
+        date_arr,
         long_win_len,
         long_err_std_n,
         short_win_len,
@@ -2178,11 +2178,11 @@ def do_sst_end_tail_check(
     return checker.get_qc_outcomes()
 
 
-@inspect_arrays(["lats", "lons", "dates", "sst", "ostia", "bgvar", "ice"])
+@inspect_arrays(["lat", "lon", "date", "sst", "ostia", "bgvar", "ice"])
 def do_sst_biased_check(
-    lons: SequenceNumberType,
-    lats: SequenceNumberType,
-    dates: SequenceDatetimeType,
+    lon: SequenceNumberType,
+    lat: SequenceNumberType,
+    date: SequenceDatetimeType,
     sst: SequenceNumberType,
     ostia: SequenceNumberType,
     ice: SequenceNumberType,
@@ -2200,11 +2200,11 @@ def do_sst_biased_check(
 
     Parameters
     ----------
-    lons : :py:obj:`~marine_qc.SequenceNumberType`
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional longitude array in degrees.
-    lats : :py:obj:`~marine_qc.SequenceNumberType`
+    lat : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional latitude array in degrees.
-    dates : :py:obj:`~marine_qc.SequenceDatetimeType`
+    date : :py:obj:`~marine_qc.SequenceDatetimeType`
         1-dimensional date array.
     sst : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional array of sea surface temperatures in K.
@@ -2253,14 +2253,14 @@ def do_sst_biased_check(
     * n_bad = 2
     * background_err_lim = 0.3
     """
-    lats_arr, lons_arr, sst_arr, ostia_arr, ice_arr, bgvar_arr, dates_arr = ensure_arrays(
-        lats=lats, lons=lons, sst=sst, ostia=ostia, ice=ice, bgvar=bgvar, dates=dates
+    lat_arr, lon_arr, sst_arr, ostia_arr, ice_arr, bgvar_arr, date_arr = ensure_arrays(
+        lat=lat, lon=lon, sst=sst, ostia=ostia, ice=ice, bgvar=bgvar, date=date
     )
 
     checker = SSTBiasedNoisyChecker(
-        lats_arr,
-        lons_arr,
-        dates_arr,
+        lat_arr,
+        lon_arr,
+        date_arr,
         sst_arr,
         ostia_arr,
         bgvar_arr,
@@ -2277,11 +2277,11 @@ def do_sst_biased_check(
     return checker.get_qc_outcomes_bias()
 
 
-@inspect_arrays(["lats", "lons", "dates", "sst", "ostia", "bgvar", "ice"])
+@inspect_arrays(["lat", "lon", "date", "sst", "ostia", "bgvar", "ice"])
 def do_sst_noisy_check(
-    lons: SequenceNumberType,
-    lats: SequenceNumberType,
-    dates: SequenceDatetimeType,
+    lon: SequenceNumberType,
+    lat: SequenceNumberType,
+    date: SequenceDatetimeType,
     sst: SequenceNumberType,
     ostia: SequenceNumberType,
     ice: SequenceNumberType,
@@ -2299,11 +2299,11 @@ def do_sst_noisy_check(
 
     Parameters
     ----------
-    lons : :py:obj:`~marine_qc.SequenceNumberType`
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional longitude array in degrees.
-    lats : :py:obj:`~marine_qc.SequenceNumberType`
+    lat : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional latitude array in degrees.
-    dates : :py:obj:`~marine_qc.SequenceDatetimeType`
+    date : :py:obj:`~marine_qc.SequenceDatetimeType`
         1-dimensional date array.
     sst : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional array of sea surface temperatures in K.
@@ -2352,14 +2352,14 @@ def do_sst_noisy_check(
     * n_bad = 2
     * background_err_lim = 0.3
     """
-    lats_arr, lons_arr, sst_arr, ostia_arr, ice_arr, bgvar_arr, dates_arr = ensure_arrays(
-        lats=lats, lons=lons, sst=sst, ostia=ostia, ice=ice, bgvar=bgvar, dates=dates
+    lat_arr, lon_arr, sst_arr, ostia_arr, ice_arr, bgvar_arr, date_arr = ensure_arrays(
+        lat=lat, lon=lon, sst=sst, ostia=ostia, ice=ice, bgvar=bgvar, date=date
     )
 
     checker = SSTBiasedNoisyChecker(
-        lats_arr,
-        lons_arr,
-        dates_arr,
+        lat_arr,
+        lon_arr,
+        date_arr,
         sst_arr,
         ostia_arr,
         bgvar_arr,
@@ -2376,11 +2376,11 @@ def do_sst_noisy_check(
     return checker.get_qc_outcomes_noise()
 
 
-@inspect_arrays(["lats", "lons", "dates", "sst", "ostia", "bgvar", "ice"])
+@inspect_arrays(["lat", "lon", "date", "sst", "ostia", "bgvar", "ice"])
 def do_sst_biased_noisy_short_check(
-    lons: SequenceNumberType,
-    lats: SequenceNumberType,
-    dates: SequenceDatetimeType,
+    lon: SequenceNumberType,
+    lat: SequenceNumberType,
+    date: SequenceDatetimeType,
     sst: SequenceNumberType,
     ostia: SequenceNumberType,
     ice: SequenceNumberType,
@@ -2398,11 +2398,11 @@ def do_sst_biased_noisy_short_check(
 
     Parameters
     ----------
-    lons : :py:obj:`~marine_qc.SequenceNumberType`
+    lon : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional longitude array in degrees.
-    lats : :py:obj:`~marine_qc.SequenceNumberType`
+    lat : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional latitude array in degrees.
-    dates : :py:obj:`~marine_qc.SequenceDatetimeType`
+    date : :py:obj:`~marine_qc.SequenceDatetimeType`
         1-dimensional date array.
     sst : :py:obj:`~marine_qc.SequenceNumberType`
         1-dimensional array of sea surface temperatures in K.
@@ -2451,14 +2451,14 @@ def do_sst_biased_noisy_short_check(
     * n_bad = 2
     * background_err_lim = 0.3
     """
-    lats_arr, lons_arr, sst_arr, ostia_arr, ice_arr, bgvar_arr, dates_arr = ensure_arrays(
-        lats=lats, lons=lons, sst=sst, ostia=ostia, ice=ice, bgvar=bgvar, dates=dates
+    lat_arr, lon_arr, sst_arr, ostia_arr, ice_arr, bgvar_arr, date_arr = ensure_arrays(
+        lat=lat, lon=lon, sst=sst, ostia=ostia, ice=ice, bgvar=bgvar, date=date
     )
 
     checker = SSTBiasedNoisyChecker(
-        lats_arr,
-        lons_arr,
-        dates_arr,
+        lat_arr,
+        lon_arr,
+        date_arr,
         sst_arr,
         ostia_arr,
         bgvar_arr,
@@ -2475,12 +2475,12 @@ def do_sst_biased_noisy_short_check(
     return checker.get_qc_outcomes_short()
 
 
-do_aground_check.__module__ = "marine_qc.buoy_tracking_qc"
-do_new_aground_check.__module__ = "marine_qc.buoy_tracking_qc"
-do_new_speed_check.__module__ = "marine_qc.buoy_tracking_qc"
-do_speed_check.__module__ = "marine_qc.buoy_tracking_qc"
-do_sst_biased_check.__module__ = "marine_qc.buoy_tracking_qc"
-do_sst_biased_noisy_short_check.__module__ = "marine_qc.buoy_tracking_qc"
-do_sst_end_tail_check.__module__ = "marine_qc.buoy_tracking_qc"
-do_sst_noisy_check.__module__ = "marine_qc.buoy_tracking_qc"
-do_sst_start_tail_check.__module__ = "marine_qc.buoy_tracking_qc"
+do_aground_check.__module__ = "marine_qc.qc_buoy_tracking"
+do_new_aground_check.__module__ = "marine_qc.qc_buoy_tracking"
+do_new_speed_check.__module__ = "marine_qc.qc_buoy_tracking"
+do_speed_check.__module__ = "marine_qc.qc_buoy_tracking"
+do_sst_biased_check.__module__ = "marine_qc.qc_buoy_tracking"
+do_sst_biased_noisy_short_check.__module__ = "marine_qc.qc_buoy_tracking"
+do_sst_end_tail_check.__module__ = "marine_qc.qc_buoy_tracking"
+do_sst_noisy_check.__module__ = "marine_qc.qc_buoy_tracking"
+do_sst_start_tail_check.__module__ = "marine_qc.qc_buoy_tracking"

--- a/src/marine_qc/quality_control/qc_buoy_tracking.py
+++ b/src/marine_qc/quality_control/qc_buoy_tracking.py
@@ -7,15 +7,12 @@ Module containing QC functions for sequential reports from a single drifting buo
 # noqa: S101
 
 from __future__ import annotations
-import math
 import warnings
-from collections.abc import Sequence
 from datetime import datetime
 
 import numpy as np
 import pandas as pd
 
-from ..helpers.astronomical_geometry import sunangle
 from ..helpers.auxiliary import (
     SequenceDatetimeType,
     SequenceNumberType,
@@ -30,8 +27,9 @@ from ..helpers.auxiliary import (
 )
 from ..helpers.spherical_geometry import sphere_distance
 from ..helpers.statistics import trim_mean, trim_std
-from ..helpers.time_control import convert_date_to_hours, day_in_year
+from ..helpers.time_control import convert_date_to_hours
 from .qc_sequential_reports import do_iquam_track_check
+from .track_check_utils import is_monotonic, track_day_test
 
 
 """
@@ -51,115 +49,6 @@ Atkinson, C.P., N.A. Rayner, J. Roberts-Jones, R.O. Smith, 2013:
 Assessing the quality of sea surface temperature observations from
 drifting buoys and ships on a platform-by-platform basis (doi:10.1002/jgrc.20257).
 """
-
-
-def track_day_test(
-    year: int,
-    month: int,
-    day: int,
-    hour: float,
-    lat: float,
-    lon: float,
-    elevdlim: float = -2.5,
-) -> bool:
-    """
-    Given date, time, lat and lon calculate if the sun elevation is > elevdlim.
-
-    This is the "day" test used by tracking QC to decide whether an SST measurement is night or day.
-    This is important because daytime diurnal heating can affect comparison with an SST background.
-    It uses the function sunangle to calculate the elevation of the sun. A default solar_zenith angle
-    of 92.5 degrees (elevation of -2.5 degrees) delimits night from day.
-
-    Parameters
-    ----------
-    year : int
-        Year.
-    month : int
-        Month.
-    day : int
-        Day.
-    hour : float
-        Hour expressed as decimal fraction (e.g. 20.75 = 20:45 pm).
-    lat : float
-        Latitude in degrees.
-    lon : float
-        Longitude in degrees.
-    elevdlim : float, default: -2.5
-        Elevation day/night delimiter in degrees above horizon.
-
-    Returns
-    -------
-    bool
-        True if daytime, else False.
-
-    Raises
-    ------
-    ValueError
-        If either year, month, day, hour, lat or lon is numerically invalid or None
-        of if either month, day, hour or lat is not in valid range.
-    """
-    if not isvalid(year):
-        raise ValueError("year is missing")
-    if not isvalid(month):
-        raise ValueError("month is missing")
-    if not isvalid(day):
-        raise ValueError("day is missing")
-    if not isvalid(hour):
-        raise ValueError("hour is missing")
-    if not isvalid(lat):
-        raise ValueError("lat is missing")
-    if not isvalid(lon):
-        raise ValueError("lon is missing")
-    if not (1 <= month <= 12):
-        raise ValueError("Month not in range 1-12")
-    if not (1 <= day <= 31):
-        raise ValueError("Day not in range 1-31")
-    if not (0 <= hour <= 24):
-        raise ValueError("Hour not in range 0-24")
-    if not (90 >= lat >= -90):
-        raise ValueError("Latitude not in range -90 to 90")
-
-    daytime = False
-
-    year2 = year
-    day2 = day_in_year(year, month, day)
-    hour2 = math.floor(hour)
-    minute2 = int((hour - math.floor(hour)) * 60.0)
-    lat2 = lat
-    lon2 = lon
-    if lat == 0:
-        lat2 = 0.0001
-    if lon == 0:
-        lon2 = 0.0001
-
-    _, elevation, _, _, _, _ = sunangle(year2, day2, hour2, minute2, 0, 0, 0, lat2, lon2)
-
-    if elevation > elevdlim:
-        daytime = True
-
-    return daytime
-
-
-def is_monotonic(inarr: np.ndarray | Sequence[int | float]) -> bool:
-    """
-    Test if elements in an array are increasing monotonically.
-
-    I.e. each element is greater than or equal to the preceding element.
-
-    Parameters
-    ----------
-    inarr : array-like of datetime, shape (n,)
-        1-dimensional date array.
-
-    Returns
-    -------
-    bool
-        True if array is increasing monotonically, False otherwise.
-    """
-    for i in range(1, len(inarr)):
-        if inarr[i] < inarr[i - 1]:
-            return False
-    return True
 
 
 class SpeedChecker:

--- a/src/marine_qc/quality_control/qc_buoy_tracking.py
+++ b/src/marine_qc/quality_control/qc_buoy_tracking.py
@@ -16,7 +16,18 @@ import numpy as np
 import pandas as pd
 
 from ..helpers.astronomical_geometry import sunangle
-from ..helpers.auxiliary import SequenceDatetimeType, SequenceNumberType, ensure_arrays, failed, inspect_arrays, isvalid, passed, untestable, untested
+from ..helpers.auxiliary import (
+    SequenceDatetimeType,
+    SequenceNumberType,
+    ensure_arrays,
+    failed,
+    inspect_arrays,
+    isvalid,
+    passed,
+    post_format_return_type,
+    untestable,
+    untested,
+)
 from ..helpers.spherical_geometry import sphere_distance
 from ..helpers.statistics import trim_mean, trim_std
 from ..helpers.time_control import convert_date_to_hours, day_in_year
@@ -1725,6 +1736,7 @@ class SSTBiasedNoisyChecker:
             self.qc_outcomes_short[:] = failed
 
 
+@post_format_return_type(["lat"])
 @inspect_arrays(["lon", "lat", "date"])
 def do_speed_check(
     lon: SequenceNumberType,
@@ -1781,6 +1793,7 @@ def do_speed_check(
     return checker.get_qc_outcomes()
 
 
+@post_format_return_type(["lat"])
 @inspect_arrays(["lon", "lat", "date"])
 def do_new_speed_check(
     lon: SequenceNumberType,
@@ -1860,6 +1873,7 @@ def do_new_speed_check(
     return checker.get_qc_outcomes()
 
 
+@post_format_return_type(["lat"])
 @inspect_arrays(["lon", "lat", "date"])
 def do_aground_check(
     lon: SequenceNumberType,
@@ -1915,6 +1929,7 @@ def do_aground_check(
     return checker.get_qc_outcomes()
 
 
+@post_format_return_type(["lat"])
 @inspect_arrays(["lon", "lat", "date"])
 def do_new_aground_check(
     lon: SequenceNumberType,
@@ -1964,6 +1979,7 @@ def do_new_aground_check(
     return checker.get_qc_outcomes()
 
 
+@post_format_return_type(["lat"])
 @inspect_arrays(["lat", "lon", "sst", "ostia", "ice", "bgvar", "date"])
 def do_sst_start_tail_check(
     lon: SequenceNumberType,
@@ -2071,6 +2087,7 @@ def do_sst_start_tail_check(
     return checker.get_qc_outcomes()
 
 
+@post_format_return_type(["lat"])
 @inspect_arrays(["lat", "lon", "sst", "ostia", "ice", "bgvar", "date"])
 def do_sst_end_tail_check(
     lon: SequenceNumberType,
@@ -2178,6 +2195,7 @@ def do_sst_end_tail_check(
     return checker.get_qc_outcomes()
 
 
+@post_format_return_type(["lat"])
 @inspect_arrays(["lat", "lon", "date", "sst", "ostia", "bgvar", "ice"])
 def do_sst_biased_check(
     lon: SequenceNumberType,
@@ -2277,6 +2295,7 @@ def do_sst_biased_check(
     return checker.get_qc_outcomes_bias()
 
 
+@post_format_return_type(["lat"])
 @inspect_arrays(["lat", "lon", "date", "sst", "ostia", "bgvar", "ice"])
 def do_sst_noisy_check(
     lon: SequenceNumberType,
@@ -2376,6 +2395,7 @@ def do_sst_noisy_check(
     return checker.get_qc_outcomes_noise()
 
 
+@post_format_return_type(["lat"])
 @inspect_arrays(["lat", "lon", "date", "sst", "ostia", "bgvar", "ice"])
 def do_sst_biased_noisy_short_check(
     lon: SequenceNumberType,

--- a/src/marine_qc/quality_control/qc_grouped_reports.py
+++ b/src/marine_qc/quality_control/qc_grouped_reports.py
@@ -42,7 +42,7 @@ from ..helpers.time_control import (
     pentad_to_month_day,
     which_pentad,
 )
-from .qc_buoy_tracking import is_monotonic
+from .track_check_utils import is_monotonic
 
 
 def get_threshold_multiplier(total_nobs: int, nob_limits: list[int], multiplier_values: list[float]) -> float:

--- a/src/marine_qc/quality_control/qc_grouped_reports.py
+++ b/src/marine_qc/quality_control/qc_grouped_reports.py
@@ -42,7 +42,7 @@ from ..helpers.time_control import (
     pentad_to_month_day,
     which_pentad,
 )
-from .buoy_tracking_qc import is_monotonic
+from .qc_buoy_tracking import is_monotonic
 
 
 def get_threshold_multiplier(total_nobs: int, nob_limits: list[int], multiplier_values: list[float]) -> float:

--- a/src/marine_qc/quality_control/qc_multiple_checks.py
+++ b/src/marine_qc/quality_control/qc_multiple_checks.py
@@ -9,6 +9,17 @@ import pandas as pd
 
 from ..helpers.auxiliary import failed, passed, untested
 from ..helpers.external_clim import get_climatological_value  # noqa: F401
+from .qc_buoy_tracking import (  # noqa: F401
+    do_aground_check,
+    do_new_aground_check,
+    do_new_speed_check,
+    do_speed_check,
+    do_sst_biased_check,
+    do_sst_biased_noisy_short_check,
+    do_sst_end_tail_check,
+    do_sst_noisy_check,
+    do_sst_start_tail_check,
+)
 from .qc_grouped_reports import (  # noqa: F401
     do_bayesian_buddy_check,
     do_mds_buddy_check,

--- a/src/marine_qc/quality_control/track_check_utils.py
+++ b/src/marine_qc/quality_control/track_check_utils.py
@@ -9,6 +9,8 @@ assumed.
 """
 
 from __future__ import annotations
+import math
+from collections.abc import Sequence
 from datetime import datetime
 
 import numpy as np
@@ -17,6 +19,7 @@ import pandas as pd
 from ..helpers import spherical_geometry as sg
 from ..helpers import spherical_geometry as sph
 from ..helpers import time_control
+from ..helpers.astronomical_geometry import sunangle
 from ..helpers.auxiliary import (
     SequenceDatetimeType,
     SequenceFloatType,
@@ -33,7 +36,7 @@ from ..helpers.spherical_geometry import (
     intermediate_point,
     sphere_distance,
 )
-from ..helpers.time_control import time_difference
+from ..helpers.time_control import day_in_year, time_difference
 
 
 def modal_speed(speeds: list[float]) -> float:
@@ -699,3 +702,112 @@ def calculate_midpoint(
     midpoint_discrepancies = sphere_distance(lat, lon, est_midpoint_lat, est_midpoint_lon)
 
     return midpoint_discrepancies
+
+
+def track_day_test(
+    year: int,
+    month: int,
+    day: int,
+    hour: float,
+    lat: float,
+    lon: float,
+    elevdlim: float = -2.5,
+) -> bool:
+    """
+    Given date, time, lat and lon calculate if the sun elevation is > elevdlim.
+
+    This is the "day" test used by tracking QC to decide whether an SST measurement is night or day.
+    This is important because daytime diurnal heating can affect comparison with an SST background.
+    It uses the function sunangle to calculate the elevation of the sun. A default solar_zenith angle
+    of 92.5 degrees (elevation of -2.5 degrees) delimits night from day.
+
+    Parameters
+    ----------
+    year : int
+        Year.
+    month : int
+        Month.
+    day : int
+        Day.
+    hour : float
+        Hour expressed as decimal fraction (e.g. 20.75 = 20:45 pm).
+    lat : float
+        Latitude in degrees.
+    lon : float
+        Longitude in degrees.
+    elevdlim : float, default: -2.5
+        Elevation day/night delimiter in degrees above horizon.
+
+    Returns
+    -------
+    bool
+        True if daytime, else False.
+
+    Raises
+    ------
+    ValueError
+        If either year, month, day, hour, lat or lon is numerically invalid or None
+        of if either month, day, hour or lat is not in valid range.
+    """
+    if not isvalid(year):
+        raise ValueError("year is missing")
+    if not isvalid(month):
+        raise ValueError("month is missing")
+    if not isvalid(day):
+        raise ValueError("day is missing")
+    if not isvalid(hour):
+        raise ValueError("hour is missing")
+    if not isvalid(lat):
+        raise ValueError("lat is missing")
+    if not isvalid(lon):
+        raise ValueError("lon is missing")
+    if not (1 <= month <= 12):
+        raise ValueError("Month not in range 1-12")
+    if not (1 <= day <= 31):
+        raise ValueError("Day not in range 1-31")
+    if not (0 <= hour <= 24):
+        raise ValueError("Hour not in range 0-24")
+    if not (90 >= lat >= -90):
+        raise ValueError("Latitude not in range -90 to 90")
+
+    daytime = False
+
+    year2 = year
+    day2 = day_in_year(year, month, day)
+    hour2 = math.floor(hour)
+    minute2 = int((hour - math.floor(hour)) * 60.0)
+    lat2 = lat
+    lon2 = lon
+    if lat == 0:
+        lat2 = 0.0001
+    if lon == 0:
+        lon2 = 0.0001
+
+    _, elevation, _, _, _, _ = sunangle(year2, day2, hour2, minute2, 0, 0, 0, lat2, lon2)
+
+    if elevation > elevdlim:
+        daytime = True
+
+    return daytime
+
+
+def is_monotonic(inarr: np.ndarray | Sequence[int | float]) -> bool:
+    """
+    Test if elements in an array are increasing monotonically.
+
+    I.e. each element is greater than or equal to the preceding element.
+
+    Parameters
+    ----------
+    inarr : array-like of datetime, shape (n,)
+        1-dimensional date array.
+
+    Returns
+    -------
+    bool
+        True if array is increasing monotonically, False otherwise.
+    """
+    for i in range(1, len(inarr)):
+        if inarr[i] < inarr[i - 1]:
+            return False
+    return True

--- a/tests/test_track_check_qc_functions.py
+++ b/tests/test_track_check_qc_functions.py
@@ -27,6 +27,8 @@ from marine_qc.quality_control.track_check_utils import (
     calculate_midpoint,
     calculate_speed_course_distance_time_difference,
     forward_discrepancy,
+    is_monotonic,
+    track_day_test,
 )
 
 
@@ -446,6 +448,54 @@ def test_forward_discrepancy_array(ship_frame):
     for i in range(1, len(result)):
         assert pytest.approx(result[i], abs=0.00001) == 0.0
     assert np.isnan(result[0])
+
+
+@pytest.mark.parametrize(
+    "inarr, expected",
+    [
+        ([2, 3, 4], True),
+        ([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], True),
+        ([2, 3, 4, 5, 4], False),
+    ],
+)
+def test_is_monotonic(inarr, expected):
+    assert is_monotonic(inarr) == expected
+
+
+@pytest.mark.parametrize(
+    "year, month, day, hour, lat, lon, elevdlim, expected",
+    [
+        (2019, 6, 21, 12.0, 50.7, -3.5, -2.5, True),
+        (2019, 6, 21, 0.0, 50.7, -3.5, -2.5, False),
+        (2019, 6, 21, 0.0, 50.7, -3.5, 89.0, False),
+        (2022, 5, 3, 12.0, 0.0, 0.0, -2.5, True),
+        (2025, 5, 26, 4.0 + 55.0 / 60.0, -20.00, 23.42, -2.5, True),
+        (2025, 5, 26, 4.0 + 35.0 / 60.0, -20.00, 23.42, -2.5, False),
+    ],
+)
+def test_daytime(year, month, day, hour, lat, lon, elevdlim, expected):
+    datetime = track_day_test(year, month, day, hour, lat, lon, elevdlim=elevdlim)
+    assert datetime == expected
+
+
+@pytest.mark.parametrize(
+    "year, month, day, hour, lat, lon",
+    [
+        (2019, 13, 21, 0.0, 50.7, -3.5),
+        (None, 12, 21, 0.0, 50.7, -3.5),
+        (2019, None, 21, 0.0, 50.7, -3.5),
+        (2019, 12, None, 0.0, 50.7, -3.5),
+        (2019, 12, 21, None, 50.7, -3.5),
+        (2019, 12, 21, 0.0, None, -3.5),
+        (2019, 12, 21, 0.0, 50.7, None),
+        (2019, 12, 43, 0.0, 50.7, -3.5),
+        (2019, 12, 21, -5.0, 50.7, -3.5),
+        (2019, 12, 21, 0.0, -99.0, -3.5),
+    ],
+)
+def test_daytime_error_invalid_parameter(year, month, day, hour, lat, lon):
+    with pytest.raises(ValueError):
+        assert track_day_test(year, month, day, hour, lat, lon, elevdlim=-2.5)
 
 
 def test_calc_alternate_speeds(ship_frame):

--- a/tests/test_trackqc.py
+++ b/tests/test_trackqc.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-import marine_qc.quality_control.buoy_tracking_qc as tqc
+import marine_qc.quality_control.qc_buoy_tracking as tqc
 from marine_qc import Flags
 
 

--- a/tests/test_trackqc.py
+++ b/tests/test_trackqc.py
@@ -319,13 +319,13 @@ def aground_check_test_data(selector):
     ],  # fmt: off
 )
 def test_generic_aground(selector, smooth_win, min_win_period, max_win_period, expected, warns):
-    lats, lons, dates = aground_check_test_data(selector)
+    lat, lon, date = aground_check_test_data(selector)
     if warns:
         with pytest.warns(UserWarning):
-            qc_outcomes = tqc.do_aground_check(lons, lats, dates, smooth_win, min_win_period, max_win_period)
+            qc_outcomes = tqc.do_aground_check(lat, lon, date, smooth_win, min_win_period, max_win_period)
     else:
-        qc_outcomes = tqc.do_aground_check(lons, lats, dates, smooth_win, min_win_period, max_win_period)
-    for i in range(len(lons)):
+        qc_outcomes = tqc.do_aground_check(lat, lon, date, smooth_win, min_win_period, max_win_period)
+    for i in range(len(lat)):
         assert qc_outcomes[i] == expected[i]
 
 
@@ -355,13 +355,13 @@ def test_generic_aground(selector, smooth_win, min_win_period, max_win_period, e
     ],  # fmt: off
 )
 def test_new_generic_aground(selector, smooth_win, min_win_period, expected, warns):
-    lats, lons, dates = aground_check_test_data(selector)
+    lat, lon, date = aground_check_test_data(selector)
     if warns:
         with pytest.warns(UserWarning):
-            qc_outcomes = tqc.do_new_aground_check(lons, lats, dates, smooth_win, min_win_period)
+            qc_outcomes = tqc.do_new_aground_check(lat, lon, date, smooth_win, min_win_period)
     else:
-        qc_outcomes = tqc.do_new_aground_check(lons, lats, dates, smooth_win, min_win_period)
-    for i in range(len(lons)):
+        qc_outcomes = tqc.do_new_aground_check(lat, lon, date, smooth_win, min_win_period)
+    for i in range(len(lat)):
         assert qc_outcomes[i] == expected[i]
 
 
@@ -583,12 +583,12 @@ def speed_check_data(selector):
     ],  # fmt: off
 )
 def test_generic_speed_tests(selector, speed_limit, min_win_period, max_win_period, expected, warns):
-    lats, lons, dates = speed_check_data(selector)
+    lat, lon, date = speed_check_data(selector)
     if warns:
         with pytest.warns(UserWarning):
-            qc_outcomes = tqc.do_speed_check(lons, lats, dates, speed_limit, min_win_period, max_win_period)
+            qc_outcomes = tqc.do_speed_check(lat, lon, date, speed_limit, min_win_period, max_win_period)
     else:
-        qc_outcomes = tqc.do_speed_check(lons, lats, dates, speed_limit, min_win_period, max_win_period)
+        qc_outcomes = tqc.do_speed_check(lat, lon, date, speed_limit, min_win_period, max_win_period)
     for i in range(len(qc_outcomes)):
         assert qc_outcomes[i] == expected[i]
 
@@ -638,13 +638,13 @@ def test_generic_new_speed_tests(
     expected,
     warns,
 ):
-    lats, lons, dates = speed_check_data(selector)
+    lat, lon, date = speed_check_data(selector)
     if warns:
         with pytest.warns(UserWarning):
             qc_outcomes = tqc.do_new_speed_check(
-                lons,
-                lats,
-                dates,
+                lat,
+                lon,
+                date,
                 speed_limit,
                 min_win_period,
                 ship_speed_limit,
@@ -654,9 +654,9 @@ def test_generic_new_speed_tests(
             )
     else:
         qc_outcomes = tqc.do_new_speed_check(
-            lons,
-            lats,
-            dates,
+            lat,
+            lon,
+            date,
             speed_limit,
             min_win_period,
             ship_speed_limit,
@@ -1473,14 +1473,14 @@ def test_generic_tailcheck(
     expected2,
     warns,
 ):
-    lat, lon, dates, sst, ostia, bgvar, ice = tailcheck_vals(selector)
+    lat, lon, date, sst, ostia, bgvar, ice = tailcheck_vals(selector)
     # First do the start tail check
     if warns:
         with pytest.warns(UserWarning):
             qc_outcomes = tqc.do_sst_start_tail_check(
-                lon,
                 lat,
-                dates,
+                lon,
+                date,
                 sst,
                 ostia,
                 ice,
@@ -1496,9 +1496,9 @@ def test_generic_tailcheck(
             )
     else:
         qc_outcomes = tqc.do_sst_start_tail_check(
-            lon,
             lat,
-            dates,
+            lon,
+            date,
             sst,
             ostia,
             ice,
@@ -1519,9 +1519,9 @@ def test_generic_tailcheck(
     if warns:
         with pytest.warns(UserWarning):
             qc_outcomes = tqc.do_sst_end_tail_check(
-                lon,
                 lat,
-                dates,
+                lon,
+                date,
                 sst,
                 ostia,
                 ice,
@@ -1537,9 +1537,9 @@ def test_generic_tailcheck(
             )
     else:
         qc_outcomes = tqc.do_sst_end_tail_check(
-            lon,
             lat,
-            dates,
+            lon,
+            date,
             sst,
             ostia,
             ice,
@@ -2340,12 +2340,12 @@ def test_sst_biased_noisy_check_generic(
     expected_short,
     warns,
 ):
-    lat, lon, dates, sst, ostia, bgvar, ice = sst_biased_noisy_check_vals(selector)
+    lat, lon, date, sst, ostia, bgvar, ice = sst_biased_noisy_check_vals(selector)
 
     inputs = [
-        lon,
         lat,
-        dates,
+        lon,
+        date,
         sst,
         ostia,
         ice,

--- a/tests/test_trackqc.py
+++ b/tests/test_trackqc.py
@@ -16,54 +16,6 @@ passed = Flags.passed
 untestable = Flags.untestable
 
 
-@pytest.mark.parametrize(
-    "year, month, day, hour, lat, lon, elevdlim, expected",
-    [
-        (2019, 6, 21, 12.0, 50.7, -3.5, -2.5, True),
-        (2019, 6, 21, 0.0, 50.7, -3.5, -2.5, False),
-        (2019, 6, 21, 0.0, 50.7, -3.5, 89.0, False),
-        (2022, 5, 3, 12.0, 0.0, 0.0, -2.5, True),
-        (2025, 5, 26, 4.0 + 55.0 / 60.0, -20.00, 23.42, -2.5, True),
-        (2025, 5, 26, 4.0 + 35.0 / 60.0, -20.00, 23.42, -2.5, False),
-    ],
-)
-def test_daytime(year, month, day, hour, lat, lon, elevdlim, expected):
-    datetime = tqc.track_day_test(year, month, day, hour, lat, lon, elevdlim=elevdlim)
-    assert datetime == expected
-
-
-@pytest.mark.parametrize(
-    "year, month, day, hour, lat, lon",
-    [
-        (2019, 13, 21, 0.0, 50.7, -3.5),
-        (None, 12, 21, 0.0, 50.7, -3.5),
-        (2019, None, 21, 0.0, 50.7, -3.5),
-        (2019, 12, None, 0.0, 50.7, -3.5),
-        (2019, 12, 21, None, 50.7, -3.5),
-        (2019, 12, 21, 0.0, None, -3.5),
-        (2019, 12, 21, 0.0, 50.7, None),
-        (2019, 12, 43, 0.0, 50.7, -3.5),
-        (2019, 12, 21, -5.0, 50.7, -3.5),
-        (2019, 12, 21, 0.0, -99.0, -3.5),
-    ],
-)
-def test_daytime_error_invalid_parameter(year, month, day, hour, lat, lon):
-    with pytest.raises(ValueError):
-        assert tqc.track_day_test(year, month, day, hour, lat, lon, elevdlim=-2.5)
-
-
-@pytest.mark.parametrize(
-    "inarr, expected",
-    [
-        ([2, 3, 4], True),
-        ([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], True),
-        ([2, 3, 4, 5, 4], False),
-    ],
-)
-def test_is_monotonic(inarr, expected):
-    assert tqc.is_monotonic(inarr) == expected
-
-
 def aground_check_test_data(selector):
     # stationary drifter
     # fmt: off


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #249
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

Since the buoy tracking QC function do not follow all standards of the the other QC functions:

- [x] convert QC outcomes from ``float`` to ``int``
- [ ] implement decorator ``convert_date`` -> since this concerns to other QC function as well we should do this in another PR
- [x] add buoy tracking QC functions to imports in ``qc_multiple_check``
- [x] rename "buoy_tracking_qc.py" into "qc_buoy_tracking.py"
- [x] implement decorator ``post_format_return_type``
- [x] convert all input parameter names from the plural into the singular
- [x] sort parameter order list

### Does this PR introduce a breaking change?
see above

### Other information:
