### PR TITLE
ignore_entries is working as expected; delete error message in notebook

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ New features and environments
 * add new function that checks whether both the date and the time is valid: do_datetime_check (:pull:`246`)
 * optionally, add coastlines in plots using visualization functions (:pull:`248`)
 * add buoy tracking QC functions to imports in quality_control.qc_multiple_check (:issue:`249`, :pull:`250`)
-* the documentation now includes example notebooks how to use ``marine_qc`` (:issue:`4`, :pull:`235`)
+* the documentation now includes example notebooks how to use ``marine_qc`` (:issue:`4`, :issue:`251`, :pull:`235`, :pull:`255`)
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/docs/notebooks/duplicates.ipynb
+++ b/docs/notebooks/duplicates.ipynb
@@ -377,7 +377,7 @@
       "id": "2ce8f2c0-7f66-474d-9383-2940d4b9fd0c",
       "metadata": {},
       "source": [
-        "If `station_id` of two observations is \"AA\" or \"BB\", they should be detected as duplicates."
+        "If `station_id` of an observation is \"AA\" or \"BB\", this entry is considered placeholder which is compatible with and equivalent to any other `station_id` value."
       ]
     },
     {
@@ -417,17 +417,8 @@
       "id": "63077603-9291-41b5-8520-f66cb195f0c9",
       "metadata": {},
       "source": [
-        "\"O\" is detected as duplicate as expected. "
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "74abf609-9e56-4077-8cfd-f5f7a2b7eeb5",
-      "metadata": {},
-      "source": [
-        "<div style=\"border-left: 4px solid #d9534f; background-color: #f8d7da; color: #721c24; padding: 10px; margin: 10px 0;\">\n",
-        "<strong>❌ Error:</strong> Unfortunately, \"M\" is detected as duplicate as well however the `station_id` is \"AB\".\n",
-        "</div>"
+        "* \"O\" is detected as duplicate as expected since we use \"BB\" as a placeholder.\n",
+        "* \"M\" is detected as duplicate as expected since we use \"AA\" and \"BB\" as placeholders which makes \"AB\" the only valid ``station_id``."
       ]
     },
     {


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #251 
- [ ] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [ ] (If applicable) Tests have been added.
- [ ] CHANGELOG.rst has been updated (with summary of main changes).
  - [ ] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* This PR deletes the "Error" message in https://marine-qc.readthedocs.io/en/latest/notebooks/duplicates.html#ignore-entries since ``ignore_entries`` gives the expected results

### Does this PR introduce a breaking change?
None

### Other information:
See #251 