### PR TITLE
Flex dec

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ New features and enhancements
 * optionally, add coastlines in plots using visualization functions (:pull:`248`)
 * add buoy tracking QC functions to imports in quality_control.qc_multiple_check (:issue:`249`, :pull:`250`)
 * the documentation now includes example notebooks how to use ``marine_qc`` (:issue:`4`, :issue:`251`, :pull:`235`, :pull:`255`)
-* quality control functions now support pandas.DataFrames as input, allowing for a more flexible way of passing data using the `data` key-word-argument (:issue:`257`, :pull:`274`)
+* quality control functions now support pandas.DataFrames as input, allowing for a more flexible way of passing data using the `data` key-word-argument (:issue:`241`, :pull:`257`)
 
 Breaking changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 ------------------
 Contributors to this version: Ludwig Lierhammer (:user:`ludwiglierhammer`)
 
-New features and environments
+New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * new_functions: `do_valid_value_check` and `do_valid_value_clim_check` are copies of the old versions from `do_missing_value_check` and `do_missing_value_clim_check` that return `1` (fail) for numerically invalid values, otherwise `0` (pass) (:issue:`205`, :pull:`206`)
 * A new checker to detect (``marine_qc.duplicate_check``), get (``marine_qc.get_duplicates``), flag (``marine_qc.flag_duplicates``) and remove (``marine_qc.remove_duplicates``) potentially duplicated observations using ``splink`` (:issue:`202`, :issue:`210`, :pull:`207`)
@@ -19,6 +19,7 @@ New features and environments
 * optionally, add coastlines in plots using visualization functions (:pull:`248`)
 * add buoy tracking QC functions to imports in quality_control.qc_multiple_check (:issue:`249`, :pull:`250`)
 * the documentation now includes example notebooks how to use ``marine_qc`` (:issue:`4`, :issue:`251`, :pull:`235`, :pull:`255`)
+* quality control functions now support pandas.DataFrames as input, allowing for a more flexible way of passing data using the `data` key-word-argument (:issue:`257`, :pull:`274`)
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
@@ -29,6 +30,7 @@ Breaking changes
 * convert all input parameter names from the plutal into the singular in buoy tracking QC function, for instance "lats" to "lat" or "lons" to "lon" (:issue:`249`, :pull:`250`)
 * sort parameter order list in buoy tracking QC functions equivalent to other QC functions, for instance ["lon", "lat", "date"] to ["lat", "lon", "date"] (:issue:`249`, :pull:`250`)
 * ``cartopy`` has been added to the dependencies (:pull:`235`)
+* when a pandas.DataFrame is provided as input to `remove_duplicates` using `data` keyword-argument, the function returns a pandas.DataFrame instead of a tuple of pandas.Series, making it easier to work with the result (:pull:`257`)
 
 Internal changes
 ^^^^^^^^^^^^^^^^
@@ -45,6 +47,8 @@ Internal changes
 * new helper function quality_control.qc_individual_report._do_date_check that is used in both do_date_check and do_datetime_check (:pull:`246`)
 * rename quality_control.buoy_tracking_qc into quality_control.qc_buoy_tracking (:issue:`249`, :pull:`250`)
 * move "is_monotonic" and "track_day_test" from quality_control.qc_buoy_tracking to quality_control.track_check_utils (:pull:`250`)
+* the `duplicate_check` function now suppresses warnings from `splink` (:pull:`257`)
+* decorators now use variable arguments instead of lists as inputs (:pull:`257`)
 
 0.3.2 (2023-04-21)
 ------------------
@@ -54,7 +58,7 @@ Announcements
 ^^^^^^^^^^^^^
 * `marine_qc` now fully supports Python 3.14 and drops support for Python 3.10. (:issue:`182`, :pull:`161`)
 
-New features and environments
+New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * `do_date_check` now supports flexible input parameters `year_init` and `year_end` that define valid year range (:pull:`184`)
 

--- a/docs/api/api_dec.rst
+++ b/docs/api/api_dec.rst
@@ -13,6 +13,9 @@ Decorators
 .. autofunction:: marine_qc.helpers.auxiliary.post_format_return_type
    :noindex:
 
+.. autofunction:: marine_qc.helpers.auxiliary.args_from_data
+   :noindex:
+
 .. autofunction:: marine_qc.helpers.external_clim.inspect_climatology
    :noindex:
 

--- a/docs/notebooks/duplicates.ipynb
+++ b/docs/notebooks/duplicates.ipynb
@@ -3,17 +3,6 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "58c9fd3c-97cd-401f-bcd6-d1d6552ebbda",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "%load_ext autoreload\n",
-        "%autoreload 2"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
       "id": "13418e05-f970-4aa9-9dd8-35b4bd0eaf71",
       "metadata": {},
       "outputs": [],
@@ -44,20 +33,6 @@
       "outputs": [],
       "source": [
         "from data import get_advanced_data"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "edebf8ff-99b7-438c-a9a8-a1def305b204",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import logging\n",
-        "\n",
-        "\n",
-        "logging.getLogger(\"splink\").setLevel(logging.ERROR)\n",
-        "logging.getLogger(\"splink.internals\").setLevel(logging.ERROR)"
       ]
     },
     {

--- a/docs/notebooks/qc_buoys.ipynb
+++ b/docs/notebooks/qc_buoys.ipynb
@@ -3,17 +3,6 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "58c9fd3c-97cd-401f-bcd6-d1d6552ebbda",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "%load_ext autoreload\n",
-        "%autoreload 2"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
       "id": "cd5ea363-0f9b-480a-a6e4-d28338c442bb",
       "metadata": {},
       "outputs": [],

--- a/docs/notebooks/qc_grouped.ipynb
+++ b/docs/notebooks/qc_grouped.ipynb
@@ -3,17 +3,6 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "61712716-951c-470c-95e3-331bf94d0620",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "%load_ext autoreload\n",
-        "%autoreload 2"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
       "id": "722c095d-cc78-4683-b73f-1c57aa78940e",
       "metadata": {},
       "outputs": [],

--- a/docs/notebooks/qc_individual.ipynb
+++ b/docs/notebooks/qc_individual.ipynb
@@ -3,17 +3,6 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "58c9fd3c-97cd-401f-bcd6-d1d6552ebbda",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "%load_ext autoreload\n",
-        "%autoreload 2"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
       "id": "cd5ea363-0f9b-480a-a6e4-d28338c442bb",
       "metadata": {},
       "outputs": [],

--- a/docs/notebooks/qc_sequential.ipynb
+++ b/docs/notebooks/qc_sequential.ipynb
@@ -3,17 +3,6 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "id": "61712716-951c-470c-95e3-331bf94d0620",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "%load_ext autoreload\n",
-        "%autoreload 2"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
       "id": "36f53233-8158-454b-b0b6-9904f5250cf8",
       "metadata": {},
       "outputs": [],

--- a/src/marine_qc/duplicate_checker/duplicates.py
+++ b/src/marine_qc/duplicate_checker/duplicates.py
@@ -1,6 +1,7 @@
 """Common Data Model (CDM) pandas duplicate check."""
 
 from __future__ import annotations
+import logging
 from typing import Any
 
 import numpy as np
@@ -10,6 +11,7 @@ from splink import DuckDBAPI, Linker
 from splink import comparison_level_library as cll
 
 from ..helpers.auxiliary import (
+    SequenceAnyType,
     SequenceDatetimeType,
     SequenceIntType,
     SequenceNumberType,
@@ -17,6 +19,9 @@ from ..helpers.auxiliary import (
     post_format_return_type,
 )
 
+
+logging.getLogger("splink").setLevel(logging.ERROR)
+logging.getLogger("splink.internals").setLevel(logging.ERROR)
 
 general_settings = {
     "link_type": "dedupe_only",
@@ -177,7 +182,7 @@ class DupDetect:
     def remove_duplicates(
         self,
         keep: str | int = "first",
-    ) -> tuple[pd.Series, ...]:
+    ) -> pd.DataFrame:
         """
         Remove duplicate entries from the dataset.
 
@@ -198,8 +203,7 @@ class DupDetect:
         if not hasattr(self, "_best_duplicates") or not hasattr(self, "_worst_duplicates"):
             self.get_duplicates(keep=keep)
 
-        result = self.data.drop(index=self._worst_duplicates)
-        return tuple(result[col] for col in result.columns)
+        return self.data.drop(index=self._worst_duplicates)
 
 
 def reindex_nulls(df: pd.DataFrame, null_label: Any) -> pd.DataFrame:
@@ -854,15 +858,18 @@ def remove_duplicates(
     detected: DupDetect | None = None,
     keep: str | int = "first",
     **kwargs: Any,
-) -> tuple[
-    SequenceStrType,
-    SequenceNumberType,
-    SequenceNumberType,
-    SequenceDatetimeType,
-    SequenceNumberType,
-    SequenceNumberType,
-    *tuple[SequenceNumberType, ...],
-]:
+) -> (
+    tuple[
+        SequenceStrType,
+        SequenceNumberType,
+        SequenceNumberType,
+        SequenceDatetimeType,
+        SequenceNumberType,
+        SequenceNumberType,
+        *tuple[SequenceAnyType, ...],
+    ]
+    | pd.DataFrame
+):
     r"""
     Remove potentially duplicated observations using `Python SPLINK Toolkit <https://moj-analytical-services.github.io/splink/index.html>`_.
 
@@ -924,9 +931,10 @@ def remove_duplicates(
 
     Returns
     -------
-    tuple of result arrays.
-        Same type as input, but with integer values
-        A tuple of all input data without the removed duplcited rows.
+    tuple of result arrays or pd.DataFrame.
+        Same type as input
+        A tuple of all input data without the removed duplicated rows
+        or a pandas.DataFrame if ``data`` is provided.
 
     Raises
     ------
@@ -972,7 +980,12 @@ def remove_duplicates(
     if detected is None:
         detected = duplicate_check(station_id, lat, lon, date, vsi, dsi, data, **kwargs)
 
-    return detected.remove_duplicates(keep=keep)
+    result = detected.remove_duplicates(keep=keep)
+
+    if isinstance(data, pd.DataFrame):
+        return result
+
+    return tuple(result[col] for col in result.columns)
 
 
 @post_format_return_type("station_id", "lat", "lon", "date", "vsi", "dsi", "data", "detected")
@@ -1115,7 +1128,7 @@ def get_duplicates(
     detected: DupDetect | None = None,
     keep: str | int = "first",
     **kwargs: Any,
-) -> SequenceIntType:
+) -> SequenceAnyType:
     r"""
     Get potentially duplicated observations using `Python SPLINK Toolkit <https://moj-analytical-services.github.io/splink/index.html>`_.
 
@@ -1177,8 +1190,8 @@ def get_duplicates(
 
     Returns
     -------
-    :py:obj:`~marine_qc.SequenceIntType`
-        Same type as input, but with integer values
+    :py:obj:`~marine_qc.SequenceValueType`
+        Same type as input, but with indexes' type values
 
           Returns the indexes of the corresponding duplicate(s).
 

--- a/src/marine_qc/duplicate_checker/duplicates.py
+++ b/src/marine_qc/duplicate_checker/duplicates.py
@@ -842,7 +842,7 @@ def duplicate_check(
     return DupDetect(groups, settings, data_orig)
 
 
-@post_format_return_type(["station_id", "lat", "lon", "date", "vsi", "dsi", "data", "detected"], multiple=True, dtype=None, keep_index=True)
+@post_format_return_type("station_id", "lat", "lon", "date", "vsi", "dsi", "data", "detected", multiple=True, dtype=None, keep_index=True)
 def remove_duplicates(
     station_id: SequenceStrType | None = None,
     lat: SequenceNumberType | None = None,
@@ -975,7 +975,7 @@ def remove_duplicates(
     return detected.remove_duplicates(keep=keep)
 
 
-@post_format_return_type(["station_id", "lat", "lon", "date", "vsi", "dsi", "data", "detected"])
+@post_format_return_type("station_id", "lat", "lon", "date", "vsi", "dsi", "data", "detected")
 def flag_duplicates(
     station_id: SequenceStrType | None = None,
     lat: SequenceNumberType | None = None,
@@ -1103,7 +1103,7 @@ def flag_duplicates(
     return detected.flag_duplicates(keep=keep)
 
 
-@post_format_return_type(["station_id", "lat", "lon", "date", "vsi", "dsi", "data", "detected"])
+@post_format_return_type("station_id", "lat", "lon", "date", "vsi", "dsi", "data", "detected")
 def get_duplicates(
     station_id: SequenceStrType | None = None,
     lat: SequenceNumberType | None = None,

--- a/src/marine_qc/helpers/auxiliary.py
+++ b/src/marine_qc/helpers/auxiliary.py
@@ -822,7 +822,7 @@ def args_from_data(*params: str) -> Callable[..., Any]:
                 raise ValueError("Use either positional arguments or 'data'. Both is not possible.")
             data = kwargs["data"].copy()
             kwargs.pop("data")
-            nargs = (data[param] for param in params)
+            nargs = (data[param] for param in params if param in data.columns)
             return func(*nargs, **kwargs)
 
         return wrapper

--- a/src/marine_qc/helpers/auxiliary.py
+++ b/src/marine_qc/helpers/auxiliary.py
@@ -738,9 +738,84 @@ def convert_units(**units_by_name: str) -> Callable[..., Any]:
 
 
 def args_from_data(*params: str) -> Callable[..., Any]:
+    r"""
+    Decorator that extracts positional arguments from a pandas.DataFrame.
+
+    If the decorated function is called with a ``data`` keyword argument,
+    the specified columns are extracted from the pandas.DataFrame and passed
+    to the function as positional arguments. This provides an alternative calling
+    convention where required positional arguments can be supplied via a
+    pandas.DataFrame instead.
+
+    The decorated function must be called using either positional arguments
+    or the ``data`` keyword argument, but not both.
+
+    Parameters
+    ----------
+    \*params : str
+        Name(s) of the pandas.DataFrame columns that correspond to the required
+        positional arguments of the decorated function.
+
+    Returns
+    -------
+    Callable[..., Any]
+        A decorator that wraps a function and allows its positional arguments
+        to be obtained from a pandas.DataFrame passed via the ``data``
+        keyword argument.
+
+    Raises
+    ------
+    ValueError
+        If both positional arguments and `data` are provided.
+    """
+
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        """
+        Decorate a function to support extracting positional arguments from a pandas.DataFrame.
+
+        Parameters
+        ----------
+        func : Callable[..., Any]
+            The function to be decorated.
+
+        Returns
+        -------
+        Callable[..., Any]
+            A wrapped function that accepts either the original positional
+            arguments or a ``data`` keyword argument containing the required
+            columns.
+        """
+
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
+            r"""
+            Call the decorated function.
+
+            If ``data`` is provided as a keyword argument, the columns
+            specified when applying the decorator are extracted from the
+            pandas.DataFrame and passed to the wrapped function as positional
+            arguments. Otherwise, the original arguments are forwarded
+            unchanged.
+
+            Parameters
+            ----------
+            \*args : Any
+                Positional arguments passed to the wrapped function.
+            \**kwargs : Any
+                Keyword arguments passed to the wrapped function. May include
+                a ``data`` keyword containing a pandas.DataFrame.
+
+            Returns
+            -------
+            Any
+                The return value of the wrapped function.
+
+            Raises
+            ------
+            ValueError
+                If both positional arguments and the ``data`` keyword
+                argument are provided.
+            """
             if "data" not in kwargs:
                 return func(*args, **kwargs)
             if len(args) > 0:

--- a/src/marine_qc/helpers/auxiliary.py
+++ b/src/marine_qc/helpers/auxiliary.py
@@ -41,6 +41,7 @@ SequenceFloatType: TypeAlias = Sequence[ScalarFloatType] | npt.NDArray[np.floati
 SequenceNumberType: TypeAlias = SequenceIntType | SequenceFloatType
 SequenceDatetimeType: TypeAlias = Sequence[ScalarDatetimeType] | npt.NDArray[np.datetime64] | pd.Series | np.ndarray
 SequenceStrType: TypeAlias = Sequence[ScalarStrType] | npt.NDArray[np.str_] | pd.Series | np.ndarray
+SequenceAnyType: TypeAlias = Sequence[Any] | npt.NDArray[Any] | pd.Series | np.ndarray
 
 ValueIntType: TypeAlias = ScalarIntType | SequenceIntType
 ValueFloatType: TypeAlias = ScalarFloatType | SequenceFloatType
@@ -207,6 +208,7 @@ def format_return_type(
         The result formatted to match the type of the first valid input value.
     """
     input_value = next((val for val in input_values if val is not None), None)
+
     if input_value is None or is_scalar_like(input_value):
         if np.ndim(result_array) > 0:
             result_array = result_array[0]
@@ -502,7 +504,7 @@ def post_format_return_type(
         """
         input_values = [original_call[param] for param in params if param in original_call]
 
-        if multiple:
+        if multiple and not isinstance(result, pd.DataFrame):
             if isinstance(dtype, type) or dtype is None:
                 return tuple(format_return_type(r, *input_values, dtype=dtype, keep_index=keep_index) for r in result)
             return_list = [format_return_type(val, *input_values, dtype=dtype[i], keep_index=keep_index) for i, val in enumerate(result)]
@@ -745,8 +747,8 @@ def args_from_data(*params: str) -> Callable[..., Any]:
                 raise ValueError("Use either positional arguments or 'data'. Both is not possible.")
             data = kwargs["data"].copy()
             kwargs.pop("data")
-            args = (data[param] for param in params)
-            return func(*args, **kwargs)
+            nargs = (data[param] for param in params)
+            return func(*nargs, **kwargs)
 
         return wrapper
 

--- a/src/marine_qc/helpers/auxiliary.py
+++ b/src/marine_qc/helpers/auxiliary.py
@@ -438,9 +438,9 @@ def generic_decorator(
 
 
 def post_format_return_type(
-    params: list[str], dtype: type | list[type] | None = int, multiple: bool = False, keep_index: bool = False
+    *params: str, dtype: type | list[type] | None = int, multiple: bool = False, keep_index: bool = False
 ) -> Callable[..., Any]:
-    """
+    r"""
     Decorator to format a function's return value to match the type of its original input(s).
 
     This decorator ensures that the output of the decorated function is converted back
@@ -451,7 +451,7 @@ def post_format_return_type(
 
     Parameters
     ----------
-    params : list of str
+    \*params : str
         List of parameter names whose original input types should be used to
         format the return value.
     dtype : type or list of type, optional, default: int
@@ -514,8 +514,8 @@ def post_format_return_type(
     return generic_decorator(post_handler=post_handler)
 
 
-def inspect_arrays(params: list[str], sortby: str | None = None) -> Callable[..., Any]:
-    """
+def inspect_arrays(*params: str, sortby: str | None = None) -> Callable[..., Any]:
+    r"""
     Decorator to convert and validate specified function input parameters as 1D NumPy arrays.
 
     This decorator ensures that specified input arguments are sequence-like, converts them
@@ -525,7 +525,7 @@ def inspect_arrays(params: list[str], sortby: str | None = None) -> Callable[...
 
     Parameters
     ----------
-    params : list of str
+    \*params : str
         Names of parameters to inspect in the decorated function. Each specified parameter
         will be converted to a 1D NumPy array and validated.
     sortby : str, optional
@@ -552,7 +552,7 @@ def inspect_arrays(params: list[str], sortby: str | None = None) -> Callable[...
 
     Examples
     --------
-    >>> @inspect_arrays(["a", "b"])
+    >>> @inspect_arrays("a", "b")
     ... def add_arrays(a, b):
     ...     return a + b
 
@@ -733,3 +733,21 @@ def convert_units(**units_by_name: str) -> Callable[..., Any]:
     DECORATOR_KWARGS[pre_handler] = {"units"}
 
     return generic_decorator(pre_handler=pre_handler)
+
+
+def args_from_data(*params: str) -> Callable[..., Any]:
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            if "data" not in kwargs:
+                return func(*args, **kwargs)
+            if len(args) > 0:
+                raise ValueError("Use either positional arguments or 'data'. Both is not possible.")
+            data = kwargs["data"].copy()
+            kwargs.pop("data")
+            args = (data[param] for param in params)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/src/marine_qc/helpers/external_clim.py
+++ b/src/marine_qc/helpers/external_clim.py
@@ -511,7 +511,7 @@ class Climatology:
         self.data = convert_units_to(self.data, target_units)
 
     @post_format_return_type("lat", dtype=float)
-    @convert_date(["month", "day"])
+    @convert_date("month", "day")
     def get_value_fast(
         self,
         lat: SequenceNumberType,
@@ -715,7 +715,7 @@ class Climatology:
         return t_index - 1
 
     @post_format_return_type("lat", dtype=float)
-    @convert_date(["month", "day"])
+    @convert_date("month", "day")
     def get_value(
         self,
         lat: SequenceNumberType,

--- a/src/marine_qc/helpers/external_clim.py
+++ b/src/marine_qc/helpers/external_clim.py
@@ -510,7 +510,7 @@ class Climatology:
             self.data.attrs["units"] = source_units
         self.data = convert_units_to(self.data, target_units)
 
-    @post_format_return_type(["lat"], dtype=float)
+    @post_format_return_type("lat", dtype=float)
     @convert_date(["month", "day"])
     def get_value_fast(
         self,
@@ -714,7 +714,7 @@ class Climatology:
             return day_in_year_array(month=month, day=day) - 1
         return t_index - 1
 
-    @post_format_return_type(["lat"], dtype=float)
+    @post_format_return_type("lat", dtype=float)
     @convert_date(["month", "day"])
     def get_value(
         self,

--- a/src/marine_qc/helpers/spherical_geometry.py
+++ b/src/marine_qc/helpers/spherical_geometry.py
@@ -60,8 +60,8 @@ def _geod_inv(
     return fwd_az, back_az, dist
 
 
-@post_format_return_type(["lat1", "lon1", "lat2", "lon2"], dtype=float)
-@inspect_arrays(["lat1", "lon1", "lat2", "lon2"])
+@post_format_return_type("lat1", "lon1", "lat2", "lon2", dtype=float)
+@inspect_arrays("lat1", "lon1", "lat2", "lon2")
 def angular_distance(
     lat1: SequenceNumberType,
     lon1: SequenceNumberType,
@@ -106,8 +106,8 @@ def angular_distance(
     return result
 
 
-@post_format_return_type(["lat1", "lon1", "lat2", "lon2"], dtype=float)
-@inspect_arrays(["lat1", "lon1", "lat2", "lon2"])
+@post_format_return_type("lat1", "lon1", "lat2", "lon2", dtype=float)
+@inspect_arrays("lat1", "lon1", "lat2", "lon2")
 def sphere_distance(
     lat1: SequenceNumberType,
     lon1: SequenceNumberType,
@@ -156,8 +156,8 @@ def sphere_distance(
     return result
 
 
-@post_format_return_type(["lat1", "lon1", "lat2", "lon2", "f"], dtype=float, multiple=True)
-@inspect_arrays(["lat1", "lon1", "lat2", "lon2", "f"])
+@post_format_return_type("lat1", "lon1", "lat2", "lon2", "f", dtype=float, multiple=True)
+@inspect_arrays("lat1", "lon1", "lat2", "lon2", "f")
 def intermediate_point(
     lat1: SequenceNumberType,
     lon1: SequenceNumberType,
@@ -214,8 +214,8 @@ def intermediate_point(
     return lat_f, lon_f
 
 
-@post_format_return_type(["lat1", "lon1", "lat2", "lon2"], dtype=float)
-@inspect_arrays(["lat1", "lon1", "lat2", "lon2"])
+@post_format_return_type("lat1", "lon1", "lat2", "lon2", dtype=float)
+@inspect_arrays("lat1", "lon1", "lat2", "lon2")
 def course_between_points(
     lat1: SequenceNumberType,
     lon1: SequenceNumberType,
@@ -253,8 +253,8 @@ def course_between_points(
     return fwd_azimuth
 
 
-@post_format_return_type(["lat1", "lon1"], dtype=float, multiple=True)
-@inspect_arrays(["lat1", "lon1"])
+@post_format_return_type("lat1", "lon1", dtype=float, multiple=True)
+@inspect_arrays("lat1", "lon1")
 def lat_lon_from_course_and_distance(
     lat1: SequenceNumberType,
     lon1: SequenceNumberType,

--- a/src/marine_qc/helpers/time_control.py
+++ b/src/marine_qc/helpers/time_control.py
@@ -648,8 +648,8 @@ def convert_date_to_hours(dates: Sequence[datetime]) -> Sequence[float]:
     return hours_elapsed
 
 
-@post_format_return_type(["times1", "times2"], dtype=float)
-@inspect_arrays(["times1", "times2"])
+@post_format_return_type("times1", "times2", dtype=float)
+@inspect_arrays("times1", "times2")
 def time_difference(times1: SequenceDatetimeType, times2: SequenceDatetimeType) -> np.ndarray:
     """
     Convert two arrays of datetimes to the difference in hours.

--- a/src/marine_qc/helpers/time_control.py
+++ b/src/marine_qc/helpers/time_control.py
@@ -23,8 +23,8 @@ from .auxiliary import (
 )
 
 
-def convert_date(params: list[str]) -> Callable[..., Any]:
-    """
+def convert_date(*params: str) -> Callable[..., Any]:
+    r"""
     Decorator to extract date components and inject them as function parameters.
 
     This decorator intercepts the 'date' argument from the function call, splits it into
@@ -33,7 +33,7 @@ def convert_date(params: list[str]) -> Callable[..., Any]:
 
     Parameters
     ----------
-    params : list of str
+    \*params : str
         List of parameter names corresponding to date components to be extracted and
         passed to the decorated function.
 

--- a/src/marine_qc/quality_control/qc_buoy_tracking.py
+++ b/src/marine_qc/quality_control/qc_buoy_tracking.py
@@ -16,6 +16,7 @@ import pandas as pd
 from ..helpers.auxiliary import (
     SequenceDatetimeType,
     SequenceNumberType,
+    args_from_data,
     ensure_arrays,
     failed,
     inspect_arrays,
@@ -1625,8 +1626,9 @@ class SSTBiasedNoisyChecker:
             self.qc_outcomes_short[:] = failed
 
 
-@post_format_return_type(["lat"])
-@inspect_arrays(["lon", "lat", "date"])
+@args_from_data("lat", "lon", "date")
+@post_format_return_type("lat")
+@inspect_arrays("lat", "lon", "date")
 def do_speed_check(
     lat: SequenceNumberType,
     lon: SequenceNumberType,
@@ -1682,8 +1684,9 @@ def do_speed_check(
     return checker.get_qc_outcomes()
 
 
-@post_format_return_type(["lat"])
-@inspect_arrays(["lon", "lat", "date"])
+@args_from_data("lat", "lon", "date")
+@post_format_return_type("lat")
+@inspect_arrays("lat", "lon", "date")
 def do_new_speed_check(
     lat: SequenceNumberType,
     lon: SequenceNumberType,
@@ -1762,8 +1765,9 @@ def do_new_speed_check(
     return checker.get_qc_outcomes()
 
 
-@post_format_return_type(["lat"])
-@inspect_arrays(["lat", "lon", "date"])
+@args_from_data("lat", "lon", "date")
+@post_format_return_type("lat")
+@inspect_arrays("lat", "lon", "date")
 def do_aground_check(
     lat: SequenceNumberType,
     lon: SequenceNumberType,
@@ -1818,8 +1822,9 @@ def do_aground_check(
     return checker.get_qc_outcomes()
 
 
-@post_format_return_type(["lat"])
-@inspect_arrays(["lon", "lat", "date"])
+@args_from_data("lat", "lon", "date")
+@post_format_return_type("lat")
+@inspect_arrays("lat", "lon", "date")
 def do_new_aground_check(
     lat: SequenceNumberType,
     lon: SequenceNumberType,
@@ -1868,8 +1873,9 @@ def do_new_aground_check(
     return checker.get_qc_outcomes()
 
 
-@post_format_return_type(["lat"])
-@inspect_arrays(["lat", "lon", "sst", "ostia", "ice", "bgvar", "date"])
+@args_from_data("lat", "lon", "sst", "ostia", "ice", "bgvar", "date")
+@post_format_return_type("lat")
+@inspect_arrays("lat", "lon", "sst", "ostia", "ice", "bgvar", "date")
 def do_sst_start_tail_check(
     lat: SequenceNumberType,
     lon: SequenceNumberType,
@@ -1976,8 +1982,9 @@ def do_sst_start_tail_check(
     return checker.get_qc_outcomes()
 
 
-@post_format_return_type(["lat"])
-@inspect_arrays(["lat", "lon", "sst", "ostia", "ice", "bgvar", "date"])
+@args_from_data("lat", "lon", "sst", "ostia", "ice", "bgvar", "date")
+@post_format_return_type("lat")
+@inspect_arrays("lat", "lon", "sst", "ostia", "ice", "bgvar", "date")
 def do_sst_end_tail_check(
     lat: SequenceNumberType,
     lon: SequenceNumberType,
@@ -2084,8 +2091,9 @@ def do_sst_end_tail_check(
     return checker.get_qc_outcomes()
 
 
-@post_format_return_type(["lat"])
-@inspect_arrays(["lat", "lon", "date", "sst", "ostia", "bgvar", "ice"])
+@args_from_data("lat", "lon", "date", "sst", "ostia", "bgvar", "ice")
+@post_format_return_type("lat")
+@inspect_arrays("lat", "lon", "date", "sst", "ostia", "bgvar", "ice")
 def do_sst_biased_check(
     lat: SequenceNumberType,
     lon: SequenceNumberType,
@@ -2184,8 +2192,9 @@ def do_sst_biased_check(
     return checker.get_qc_outcomes_bias()
 
 
-@post_format_return_type(["lat"])
-@inspect_arrays(["lat", "lon", "date", "sst", "ostia", "bgvar", "ice"])
+@args_from_data("lat", "lon", "date", "sst", "ostia", "bgvar", "ice")
+@post_format_return_type("lat")
+@inspect_arrays("lat", "lon", "date", "sst", "ostia", "bgvar", "ice")
 def do_sst_noisy_check(
     lat: SequenceNumberType,
     lon: SequenceNumberType,
@@ -2284,8 +2293,9 @@ def do_sst_noisy_check(
     return checker.get_qc_outcomes_noise()
 
 
-@post_format_return_type(["lat"])
-@inspect_arrays(["lat", "lon", "date", "sst", "ostia", "bgvar", "ice"])
+@args_from_data("lat", "lon", "date", "sst", "ostia", "bgvar", "ice")
+@post_format_return_type("lat")
+@inspect_arrays("lat", "lon", "date", "sst", "ostia", "bgvar", "ice")
 def do_sst_biased_noisy_short_check(
     lat: SequenceNumberType,
     lon: SequenceNumberType,

--- a/src/marine_qc/quality_control/qc_grouped_reports.py
+++ b/src/marine_qc/quality_control/qc_grouped_reports.py
@@ -15,6 +15,7 @@ from ..helpers.auxiliary import (
     SequenceDatetimeType,
     SequenceIntType,
     SequenceNumberType,
+    args_from_data,
     convert_units,
     ensure_arrays,
     failed,
@@ -102,7 +103,7 @@ class SuperObsGrid:
         self.nobs = np.zeros((360, 180, 73))  # type: np.ndarray
 
     @convert_date(["month", "day"])
-    @inspect_arrays(["lat", "lon", "value", "month", "day"])
+    @inspect_arrays("lat", "lon", "value", "month", "day")
     def add_multiple_observations(
         self,
         lat: SequenceNumberType,
@@ -483,8 +484,9 @@ class SuperObsGrid:
         return float(self.buddy_stdev[xindex, yindex, pindex])
 
 
-@post_format_return_type(["value"])
-@inspect_arrays(["lat", "lon", "date", "value", "climatology"])
+@args_from_data("lat", "lon", "date", "value")
+@post_format_return_type("value")
+@inspect_arrays("lat", "lon", "date", "value", "climatology")
 @convert_units(lat="degrees", lon="degrees")
 @inspect_climatology("climatology")
 def do_mds_buddy_check(
@@ -620,8 +622,9 @@ def do_mds_buddy_check(
     return qc_outcomes
 
 
-@post_format_return_type(["value"])
-@inspect_arrays(["lat", "lon", "date", "value", "climatology"])
+@args_from_data("lat", "lon", "date", "value")
+@post_format_return_type("value")
+@inspect_arrays("lat", "lon", "date", "value", "climatology")
 @convert_units(lat="degrees", lon="degrees")
 @inspect_climatology("climatology")
 def do_bayesian_buddy_check(

--- a/src/marine_qc/quality_control/qc_grouped_reports.py
+++ b/src/marine_qc/quality_control/qc_grouped_reports.py
@@ -102,7 +102,7 @@ class SuperObsGrid:
         self.buddy_stdev = np.zeros((360, 180, 73))  # type: np.ndarray
         self.nobs = np.zeros((360, 180, 73))  # type: np.ndarray
 
-    @convert_date(["month", "day"])
+    @convert_date("month", "day")
     @inspect_arrays("lat", "lon", "value", "month", "day")
     def add_multiple_observations(
         self,

--- a/src/marine_qc/quality_control/qc_individual_reports.py
+++ b/src/marine_qc/quality_control/qc_individual_reports.py
@@ -16,6 +16,7 @@ from ..helpers.auxiliary import (
     ValueFloatType,
     ValueIntType,
     ValueNumberType,
+    args_from_data,
     convert_units,
     ensure_arrays,
     failed,
@@ -244,8 +245,9 @@ def _do_daytime_check(
     return result
 
 
-@post_format_return_type(["value"])
-@inspect_arrays(["value"])
+@args_from_data("value")
+@post_format_return_type("value")
+@inspect_arrays("value")
 def value_check(value: ValueNumberType, valid_flag: int = passed, invalid_flag: int = failed) -> ValueIntType:
     """
     Check if a value is equal to None or numerically invalid (NaN).
@@ -281,8 +283,9 @@ def value_check(value: ValueNumberType, valid_flag: int = passed, invalid_flag: 
     return result
 
 
-@post_format_return_type(["lat", "lon"])
-@inspect_arrays(["lat", "lon"])
+@args_from_data("lat", "lon")
+@post_format_return_type("lat", "lon")
+@inspect_arrays("lat", "lon")
 @convert_units(lat="degrees", lon="degrees")
 def do_position_check(lat: ValueNumberType, lon: ValueNumberType) -> ValueIntType:
     """
@@ -332,9 +335,10 @@ def do_position_check(lat: ValueNumberType, lon: ValueNumberType) -> ValueIntTyp
     return result
 
 
-@post_format_return_type(["date", "year"])
+@args_from_data("year", "month", "day")
+@post_format_return_type("date", "year")
 @convert_date(["year", "month", "day"])
-@inspect_arrays(["year", "month", "day"])
+@inspect_arrays("year", "month", "day")
 def do_date_check(
     date: ValueDatetimeType = None,
     year: ValueIntType = None,
@@ -384,9 +388,10 @@ def do_date_check(
     return _do_date_check(year_arr, month_arr, day_arr, year_init, year_end)
 
 
-@post_format_return_type(["date", "hour"])
+@args_from_data("hour")
+@post_format_return_type("date", "hour")
 @convert_date(["hour"])
-@inspect_arrays(["hour"])
+@inspect_arrays("hour")
 def do_time_check(
     date: ValueDatetimeType = None,
     hour: ValueFloatType = None,
@@ -422,9 +427,10 @@ def do_time_check(
     return _do_time_check(hour_arr)
 
 
-@post_format_return_type(["date", "year"])
+@args_from_data("year", "month", "day", "hour")
+@post_format_return_type("date", "year")
 @convert_date(["year", "month", "day", "hour"])
-@inspect_arrays(["year", "month", "day", "hour"])
+@inspect_arrays("year", "month", "day", "hour")
 def do_datetime_check(
     date: ValueDatetimeType = None,
     year: ValueIntType = None,
@@ -479,9 +485,10 @@ def do_datetime_check(
     return result
 
 
-@post_format_return_type(["date", "year"])
+@args_from_data("year", "month", "day", "hour", "lat", "lon")
+@post_format_return_type("date", "year")
 @convert_date(["year", "month", "day", "hour"])
-@inspect_arrays(["year", "month", "day", "hour", "lat", "lon"])
+@inspect_arrays("year", "month", "day", "hour", "lat", "lon")
 @convert_units(lat="degrees", lon="degrees")
 def do_day_check(
     date: ValueDatetimeType = None,
@@ -559,9 +566,10 @@ def do_day_check(
     return _do_daytime_check(year_arr, month_arr, day_arr, hour_arr, lat_arr, lon_arr, time_since_sun_above_horizon, mode="day")
 
 
-@post_format_return_type(["date", "year"])
+@args_from_data("year", "month", "day", "hour", "lat", "lon")
+@post_format_return_type("date", "year")
 @convert_date(["year", "month", "day", "hour"])
-@inspect_arrays(["year", "month", "day", "hour", "lat", "lon"])
+@inspect_arrays("year", "month", "day", "hour", "lat", "lon")
 @convert_units(lat="degrees", lon="degrees")
 def do_night_check(
     date: ValueDatetimeType = None,
@@ -677,7 +685,6 @@ def do_missing_value_check(value: ValueNumberType) -> ValueIntType:
     return value_check(value, valid_flag=failed, invalid_flag=passed)
 
 
-@inspect_climatology("climatology")
 def do_missing_value_clim_check(climatology: ClimArgType, **kwargs: Any) -> ValueIntType:
     r"""
     Check if a climatological value is equal to None or numerically invalid (NaN).
@@ -773,8 +780,9 @@ def do_valid_value_clim_check(climatology: ClimArgType, **kwargs: Any) -> ValueI
     return value_check(climatology)
 
 
-@post_format_return_type(["value"])
-@inspect_arrays(["value"])
+@args_from_data("value")
+@post_format_return_type("value")
+@inspect_arrays("value")
 @convert_units(value="unknown", limits="unknown")
 def do_hard_limit_check(
     value: ValueNumberType,
@@ -824,8 +832,9 @@ def do_hard_limit_check(
     return result
 
 
-@post_format_return_type(["value"])
-@inspect_arrays(["value", "climatology"])
+@args_from_data("value")
+@post_format_return_type("value")
+@inspect_arrays("value", "climatology")
 @convert_units(value="unknown", climatology="unknown")
 @inspect_climatology("climatology", optional="standard_deviation")
 def do_climatology_check(
@@ -935,8 +944,9 @@ def do_climatology_check(
     return result
 
 
-@post_format_return_type(["dpt", "at2"])
-@inspect_arrays(["dpt", "at2"])
+@args_from_data("dpt", "at2")
+@post_format_return_type("dpt", "at2")
+@inspect_arrays("dpt", "at2")
 @convert_units(dpt="K", at2="K")
 def do_supersaturation_check(dpt: ValueNumberType, at2: ValueNumberType) -> ValueIntType:
     """
@@ -982,8 +992,9 @@ def do_supersaturation_check(dpt: ValueNumberType, at2: ValueNumberType) -> Valu
     return result
 
 
-@post_format_return_type(["sst"])
-@inspect_arrays(["sst"])
+@args_from_data("sst")
+@post_format_return_type("sst")
+@inspect_arrays("sst")
 @convert_units(sst="K", freezing_point="K")
 def do_sst_freeze_check(
     sst: ValueNumberType,
@@ -1066,8 +1077,9 @@ def do_sst_freeze_check(
     return result
 
 
-@post_format_return_type(["wind_speed", "wind_direction"])
-@inspect_arrays(["wind_speed", "wind_direction"])
+@args_from_data("wind_speed", "wind_direction")
+@post_format_return_type("wind_speed", "wind_direction")
+@inspect_arrays("wind_speed", "wind_direction")
 def do_wind_consistency_check(wind_speed: ValueNumberType, wind_direction: ValueNumberType) -> ValueIntType:
     """
     Test to compare windspeed to winddirection to check if they are consistent.
@@ -1167,8 +1179,9 @@ def _do_mask_check(
     return result
 
 
-@post_format_return_type(["lat", "lon"])
-@inspect_arrays(["lat", "lon", "land_sea_mask"])
+@args_from_data("lat", "lon")
+@post_format_return_type("lat", "lon")
+@inspect_arrays("lat", "lon", "land_sea_mask")
 @convert_units(lat="degrees", lon="degrees")
 @inspect_climatology("land_sea_mask")
 def do_landlocked_check(
@@ -1214,8 +1227,9 @@ def do_landlocked_check(
     return _do_mask_check(lat=lat_arr, lon=lon_arr, mask=mask_arr, flag=land_flag)
 
 
-@post_format_return_type(["lat", "lon"])
-@inspect_arrays(["lat", "lon", "sea_land_mask"])
+@args_from_data("lat", "lon")
+@post_format_return_type("lat", "lon")
+@inspect_arrays("lat", "lon", "sea_land_mask")
 @convert_units(lat="degrees", lon="degrees")
 @inspect_climatology("sea_land_mask")
 def do_maritime_check(

--- a/src/marine_qc/quality_control/qc_individual_reports.py
+++ b/src/marine_qc/quality_control/qc_individual_reports.py
@@ -337,7 +337,7 @@ def do_position_check(lat: ValueNumberType, lon: ValueNumberType) -> ValueIntTyp
 
 @args_from_data("year", "month", "day")
 @post_format_return_type("date", "year")
-@convert_date(["year", "month", "day"])
+@convert_date("year", "month", "day")
 @inspect_arrays("year", "month", "day")
 def do_date_check(
     date: ValueDatetimeType = None,
@@ -390,7 +390,7 @@ def do_date_check(
 
 @args_from_data("hour")
 @post_format_return_type("date", "hour")
-@convert_date(["hour"])
+@convert_date("hour")
 @inspect_arrays("hour")
 def do_time_check(
     date: ValueDatetimeType = None,
@@ -429,7 +429,7 @@ def do_time_check(
 
 @args_from_data("year", "month", "day", "hour")
 @post_format_return_type("date", "year")
-@convert_date(["year", "month", "day", "hour"])
+@convert_date("year", "month", "day", "hour")
 @inspect_arrays("year", "month", "day", "hour")
 def do_datetime_check(
     date: ValueDatetimeType = None,
@@ -487,7 +487,7 @@ def do_datetime_check(
 
 @args_from_data("year", "month", "day", "hour", "lat", "lon")
 @post_format_return_type("date", "year")
-@convert_date(["year", "month", "day", "hour"])
+@convert_date("year", "month", "day", "hour")
 @inspect_arrays("year", "month", "day", "hour", "lat", "lon")
 @convert_units(lat="degrees", lon="degrees")
 def do_day_check(
@@ -568,7 +568,7 @@ def do_day_check(
 
 @args_from_data("year", "month", "day", "hour", "lat", "lon")
 @post_format_return_type("date", "year")
-@convert_date(["year", "month", "day", "hour"])
+@convert_date("year", "month", "day", "hour")
 @inspect_arrays("year", "month", "day", "hour", "lat", "lon")
 @convert_units(lat="degrees", lon="degrees")
 def do_night_check(

--- a/src/marine_qc/quality_control/qc_individual_reports.py
+++ b/src/marine_qc/quality_control/qc_individual_reports.py
@@ -335,7 +335,7 @@ def do_position_check(lat: ValueNumberType, lon: ValueNumberType) -> ValueIntTyp
     return result
 
 
-@args_from_data("year", "month", "day")
+@args_from_data("date", "year", "month", "day")
 @post_format_return_type("date", "year")
 @convert_date("year", "month", "day")
 @inspect_arrays("year", "month", "day")
@@ -388,7 +388,7 @@ def do_date_check(
     return _do_date_check(year_arr, month_arr, day_arr, year_init, year_end)
 
 
-@args_from_data("hour")
+@args_from_data("date", "hour")
 @post_format_return_type("date", "hour")
 @convert_date("hour")
 @inspect_arrays("hour")
@@ -427,7 +427,7 @@ def do_time_check(
     return _do_time_check(hour_arr)
 
 
-@args_from_data("year", "month", "day", "hour")
+@args_from_data("date", "year", "month", "day", "hour")
 @post_format_return_type("date", "year")
 @convert_date("year", "month", "day", "hour")
 @inspect_arrays("year", "month", "day", "hour")
@@ -485,7 +485,7 @@ def do_datetime_check(
     return result
 
 
-@args_from_data("year", "month", "day", "hour", "lat", "lon")
+@args_from_data("date", "year", "month", "day", "hour", "lat", "lon")
 @post_format_return_type("date", "year")
 @convert_date("year", "month", "day", "hour")
 @inspect_arrays("year", "month", "day", "hour", "lat", "lon")
@@ -566,7 +566,7 @@ def do_day_check(
     return _do_daytime_check(year_arr, month_arr, day_arr, hour_arr, lat_arr, lon_arr, time_since_sun_above_horizon, mode="day")
 
 
-@args_from_data("year", "month", "day", "hour", "lat", "lon")
+@args_from_data("date", "year", "month", "day", "hour", "lat", "lon")
 @post_format_return_type("date", "year")
 @convert_date("year", "month", "day", "hour")
 @inspect_arrays("year", "month", "day", "hour", "lat", "lon")

--- a/src/marine_qc/quality_control/qc_sequential_reports.py
+++ b/src/marine_qc/quality_control/qc_sequential_reports.py
@@ -15,6 +15,7 @@ from ..helpers.auxiliary import (
     SequenceDatetimeType,
     SequenceIntType,
     SequenceNumberType,
+    args_from_data,
     convert_units,
     ensure_arrays,
     failed,
@@ -39,8 +40,9 @@ from .track_check_utils import (
 )
 
 
-@post_format_return_type(["value"])
-@inspect_arrays(["value", "lat", "lon", "date"], sortby="date")
+@args_from_data("value", "lat", "lon", "date")
+@post_format_return_type("value")
+@inspect_arrays("value", "lat", "lon", "date", sortby="date")
 @convert_units(lat="degrees", lon="degrees")
 def do_spike_check(
     value: SequenceNumberType,
@@ -165,8 +167,9 @@ def do_spike_check(
     return spike_qc
 
 
-@post_format_return_type(["vsi"])
-@inspect_arrays(["vsi", "dsi", "lat", "lon", "date"], sortby="date")
+@args_from_data("vsi", "dsi", "lat", "lon", "date")
+@post_format_return_type("vsi")
+@inspect_arrays("vsi", "dsi", "lat", "lon", "date", sortby="date")
 @convert_units(vsi="km/h", dsi="degrees", lat="degrees", lon="degrees")
 def do_track_check(
     vsi: SequenceNumberType,
@@ -332,8 +335,9 @@ def do_track_check(
     return trk
 
 
-@post_format_return_type(["value"])
-@inspect_arrays(["value"])
+@args_from_data("value")
+@post_format_return_type("value")
+@inspect_arrays("value")
 def do_few_check(
     value: SequenceNumberType,
 ) -> SequenceIntType:
@@ -377,8 +381,9 @@ def do_few_check(
     return [passed] * number_of_obs
 
 
-@post_format_return_type(["at"])
-@inspect_arrays(["at", "dpt", "lat", "lon", "date"], sortby="date")
+@args_from_data("at", "dpt", "lat", "lon", "date")
+@post_format_return_type("at")
+@inspect_arrays("at", "dpt", "lat", "lon", "date", sortby="date")
 @convert_units(at="K", dpt="K", lat="degrees", lon="degrees")
 def find_saturated_runs(
     at: SequenceNumberType,
@@ -469,8 +474,9 @@ def find_saturated_runs(
     return qc_flags
 
 
-@post_format_return_type(["value"])
-@inspect_arrays(["value"])
+@args_from_data("value")
+@post_format_return_type("value")
+@inspect_arrays("value")
 def find_multiple_rounded_values(value: SequenceNumberType, min_count: int, threshold: float) -> SequenceIntType:
     """
     Find instances when more than "threshold" of the observations are whole numbers and set the 'round' flag.
@@ -536,8 +542,9 @@ def find_multiple_rounded_values(value: SequenceNumberType, min_count: int, thre
     return rounded
 
 
-@post_format_return_type(["value"])
-@inspect_arrays(["value"])
+@args_from_data("value")
+@post_format_return_type("value")
+@inspect_arrays("value")
 def find_repeated_values(value: SequenceNumberType, min_count: int, threshold: float) -> SequenceIntType:
     """
     Find cases where more than a given proportion of SSTs have the same value.
@@ -606,8 +613,9 @@ def find_repeated_values(value: SequenceNumberType, min_count: int, threshold: f
     return rep
 
 
-@post_format_return_type(["lat"])
-@inspect_arrays(["lat", "lon", "date"], sortby="date")
+@args_from_data("lat", "lon", "date")
+@post_format_return_type("lat")
+@inspect_arrays("lat", "lon", "date", sortby="date")
 @convert_units(lat="degrees", lon="degrees")
 def do_iquam_track_check(
     lat: SequenceNumberType,

--- a/src/marine_qc/quality_control/track_check_utils.py
+++ b/src/marine_qc/quality_control/track_check_utils.py
@@ -124,8 +124,8 @@ def set_speed_limits(amode: float) -> tuple[float, float, float]:
     return amode * 1.25, float(np.asarray(convert_to(30.0, "knots", "km/h"), dtype=float)), amode * 0.75
 
 
-@post_format_return_type(["alat1"], dtype=float, multiple=True)
-@inspect_arrays(["alat1", "alon1", "avs", "ads", "timediff"])
+@post_format_return_type("alat1", dtype=float, multiple=True)
+@inspect_arrays("alat1", "alon1", "avs", "ads", "timediff")
 def increment_position(
     alat1: SequenceNumberType,
     alon1: SequenceNumberType,
@@ -171,8 +171,8 @@ def increment_position(
     return lat, lon
 
 
-@post_format_return_type(["dsi"], dtype=float)
-@inspect_arrays(["dsi", "directions"])
+@post_format_return_type("dsi", dtype=float)
+@inspect_arrays("dsi", "directions")
 def direction_continuity(
     dsi: SequenceNumberType,
     directions: SequenceNumberType,
@@ -237,8 +237,8 @@ def direction_continuity(
     return result
 
 
-@post_format_return_type(["vsi"], dtype=float)
-@inspect_arrays(["vsi", "speeds"])
+@post_format_return_type("vsi", dtype=float)
+@inspect_arrays("vsi", "speeds")
 def speed_continuity(
     vsi: SequenceNumberType,
     speeds: SequenceNumberType,
@@ -299,8 +299,8 @@ def speed_continuity(
     return result
 
 
-@post_format_return_type(["vsi"], dtype=float)
-@inspect_arrays(["vsi", "time_differences", "fwd_diff_from_estimated", "rev_diff_from_estimated"])
+@post_format_return_type("vsi", dtype=float)
+@inspect_arrays("vsi", "time_differences", "fwd_diff_from_estimated", "rev_diff_from_estimated")
 def check_distance_from_estimate(
     vsi: SequenceNumberType,
     time_differences: SequenceNumberType,
@@ -425,8 +425,8 @@ def calculate_course_parameters(
     return speed, distance, course, timediff
 
 
-@post_format_return_type(["lat"], dtype=float, multiple=True)
-@inspect_arrays(["lat", "lon", "date"])
+@post_format_return_type("lat", dtype=float, multiple=True)
+@inspect_arrays("lat", "lon", "date")
 @convert_units(lat="degrees", lon="degrees")
 def calculate_speed_course_distance_time_difference(
     lat: SequenceNumberType,
@@ -487,8 +487,8 @@ def calculate_speed_course_distance_time_difference(
     return speed, distance, course, timediff
 
 
-@post_format_return_type(["vsi"], dtype=float)
-@inspect_arrays(["lat", "lon", "date", "vsi", "dsi"], sortby="date")
+@post_format_return_type("vsi", dtype=float)
+@inspect_arrays("lat", "lon", "date", "vsi", "dsi", sortby="date")
 @convert_units(vsi="km/h", dsi="degrees", lat="degrees", lon="degrees")
 def forward_discrepancy(
     lat: SequenceNumberType,
@@ -559,8 +559,8 @@ def forward_discrepancy(
     return distance_from_est_location
 
 
-@post_format_return_type(["vsi"], dtype=float)
-@inspect_arrays(["lat", "lon", "date", "vsi", "dsi"], sortby="date")
+@post_format_return_type("vsi", dtype=float)
+@inspect_arrays("lat", "lon", "date", "vsi", "dsi", sortby="date")
 @convert_units(vsi="km/h", dsi="degrees", lat="degrees", lon="degrees")
 def backward_discrepancy(
     lat: SequenceNumberType,
@@ -637,8 +637,8 @@ def backward_discrepancy(
     return distance_from_est_location
 
 
-@post_format_return_type(["lat"], dtype=float)
-@inspect_arrays(["lat", "lon", "timediff"])
+@post_format_return_type("lat", dtype=float)
+@inspect_arrays("lat", "lon", "timediff")
 @convert_units(lat="degrees", lon="degrees")
 def calculate_midpoint(
     lat: SequenceNumberType,

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -28,12 +28,12 @@ def _convert_function2(value):
     return value
 
 
-@inspect_arrays(["value1", "value2"])
+@inspect_arrays("value1", "value2")
 def _array_function(value1, value2):
     return value1, value2
 
 
-@inspect_arrays(["value1", "value3"])
+@inspect_arrays("value1", "value3")
 def _array_function2(value1, value2):
     return value1, value2
 
@@ -54,7 +54,7 @@ def test_convert_units(units):
     assert result == 30.0 + 273.15
 
 
-@post_format_return_type(["value"])
+@post_format_return_type("value")
 def _format_function(value):
     return pd.Series(value) + 5
 
@@ -98,7 +98,7 @@ def test_inspect_arrays_raise_dimension():
 
 
 def test_inspect_arrays_raise_length():
-    error_msg = "Input ['value1', 'value2'] must all have the same length."
+    error_msg = "Input ('value1', 'value2') must all have the same length."
     escaped_msg = re.escape(error_msg)
     with pytest.raises(ValueError, match=escaped_msg):
         _array_function([1, 2, 3, 4], [1, 2, 3])
@@ -155,7 +155,7 @@ def test_post_format_return_type_simple(value, expected, array_type):
 )
 def test_post_format_return_type_multiple(dtype, multiple, expected_len):
     @post_format_return_type(
-        params=["value"],
+        "value",
         dtype=dtype,
         multiple=multiple,
         keep_index=False,
@@ -174,7 +174,7 @@ def test_post_format_return_type_multiple(dtype, multiple, expected_len):
 
 def test_post_format_return_type_raises():
     @post_format_return_type(
-        params=["value"],
+        "value",
         dtype=[int, int],
         multiple=False,
         keep_index=False,

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -7,6 +7,7 @@ import pytest
 from pint.errors import DimensionalityError
 
 from marine_qc.helpers.auxiliary import (
+    args_from_data,
     convert_to,
     convert_units,
     ensure_arrays,
@@ -38,14 +39,19 @@ def _array_function2(value1, value2):
     return value1, value2
 
 
-@convert_date(["year", "month", "day"])
+@convert_date("year", "month", "day")
 def _date_function(date, year=None, month=None, day=None):
     return year, month, day
 
 
-@convert_date(["year2", "month", "day"])
+@convert_date("year2", "month", "day")
 def _date_function2(date, year=None, month=None, day=None):
     return year, month, day
+
+
+@args_from_data("lat", "lon")
+def _data_function(lat, lon):
+    return lat, lon
 
 
 @pytest.mark.parametrize("units", [{"value": "degC"}, "degC"])
@@ -57,6 +63,12 @@ def test_convert_units(units):
 @post_format_return_type("value")
 def _format_function(value):
     return pd.Series(value) + 5
+
+
+@args_from_data("date")
+@convert_date("year")
+def _combi_function(date=None, year=None):
+    return year
 
 
 def test_convert_units_no_conversion():
@@ -109,6 +121,47 @@ def test_inspect_arrays_raise_parameter():
         _array_function2(1, 2)
 
 
+def test_args_from_data_pass():
+    data = pd.DataFrame(
+        {
+            "lat": [10.0, 15.0, 20.0],
+            "lon": [-10.0, 0.0, 10.0],
+            "year": [2024, 2025, 2026],
+        }
+    )
+    result = _data_function(data=data)
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+
+    pd.testing.assert_series_equal(result[0], data["lat"])
+    pd.testing.assert_series_equal(result[1], data["lon"])
+
+
+def test_args_from_data_valueerror():
+    data = pd.DataFrame(
+        {
+            "lat": [10.0, 15.0, 20.0],
+            "lon": [-10.0, 0.0, 10.0],
+            "year": [2024, 2025, 2026],
+        }
+    )
+
+    with pytest.raises(ValueError, match="Use either positional arguments or 'data'. Both is not possible."):
+        _data_function(data["lat"], data["lon"], data=data)
+
+
+def test_args_from_data_typeerror():
+    data = pd.DataFrame(
+        {
+            "year": [2024, 2025, 2026],
+        }
+    )
+
+    with pytest.raises(TypeError, match="missing 2 required positional arguments"):
+        _data_function(data=data)
+
+
 @pytest.mark.parametrize(
     "date, year, month, day",
     [["2019-9-27", 2019, 9, 27], ["2019-9", 2019, 9, 1], ["2019", 2019, 1, 1]],
@@ -123,6 +176,13 @@ def test_convert_date(date, year, month, day):
 def test_convert_date_raise():
     with pytest.raises(ValueError, match="Parameter 'year2' is not a valid parameter."):
         _date_function2(pd.to_datetime("2019-09-27"))
+
+
+def test_combi_decorators():
+    data = pd.DataFrame({"date": ["2025-01-01T12:00:00", "2026-01-01T12:00.00", "2027-01-01T12:00:00"]})
+    result = _combi_function(data=data)
+    print(result)
+    assert result == [2025, 2026, 2027]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -647,23 +647,14 @@ def test_fla_duplicates_raises():
 )
 def test_remove_duplicates_basic(directly, dummy_data, keep, exp_idx):
     if directly is True:
-        result = remove_duplicates(**dummy_data.to_dict(), keep=keep)
+        result = remove_duplicates(data=dummy_data, keep=keep)
     elif directly is False:
-        dd = duplicate_check(**dummy_data.to_dict())
+        dd = duplicate_check(data=dummy_data)
         result = dd.remove_duplicates(keep=keep)
 
-    assert isinstance(result, tuple)
-    assert len(result) == 7
-    for r in result:
-        assert isinstance(r, pd.Series)
+    assert isinstance(result, pd.DataFrame)
 
-    pd.testing.assert_series_equal(result[0], dummy_data["station_id"].iloc[exp_idx])
-    pd.testing.assert_series_equal(result[1], dummy_data["lat"].iloc[exp_idx])
-    pd.testing.assert_series_equal(result[2], dummy_data["lon"].iloc[exp_idx])
-    pd.testing.assert_series_equal(result[3], dummy_data["date"].iloc[exp_idx])
-    pd.testing.assert_series_equal(result[4], dummy_data["vsi"].iloc[exp_idx])
-    pd.testing.assert_series_equal(result[5], dummy_data["dsi"].iloc[exp_idx])
-    pd.testing.assert_series_equal(result[6], dummy_data["flag"].iloc[exp_idx])
+    pd.testing.assert_frame_equal(result, dummy_data.iloc[exp_idx])
 
 
 def test_remove_duplicates_detected(dummy_data):

--- a/tests/test_individual_report_qc.py
+++ b/tests/test_individual_report_qc.py
@@ -141,6 +141,20 @@ def test_do_position_check_untestable():
     assert do_position_check(0.0, None) == 2
 
 
+def test_do_position_check_df():
+    data = pd.DataFrame(
+        {
+            "lat": [0.0, 45.0, 91.0, -91.0, 0.0, 0.0, None, 0.0],
+            "lon": [0.0, 125.0, 0.0, 0.0, -180.1, 360.1, 0.0, None],
+        }
+    )
+    expected = pd.Series([passed, passed, failed, failed, failed, failed, untestable, untestable])
+
+    result = do_position_check(data=data)
+
+    pd.testing.assert_series_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     "year, month, day, expected",
     [
@@ -197,6 +211,15 @@ def test_do_date_check_untestable():
 def test_do_date_check_year_range(year, month, day, expected):
     result = do_date_check(year=year, month=month, day=day, year_init=2023, year_end=2025)
     assert result == expected
+
+
+def test_do_date_check_df():
+    data = pd.DataFrame({"date": ["2023-01-01", "2023-01-31", "2024-02-29", "2000-02-30"]})
+    expected = pd.Series([passed, passed, passed, untestable])
+
+    result = do_date_check(data=data)
+
+    pd.testing.assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #241 
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Quality control functions now support pandas.DataFrames as input, allowing for a more flexible way of passing data using the `data` key-word-argument.
* Internally, the `duplicate_check` function now suppresses warnings from `splink`.
* Internally, decorators now use variable arguments instead of lists as inputs.

### Does this PR introduce a breaking change?
When a pandas.DataFrame is provided as input to `remove_duplicates` using `data` keyword-argument, the function returns a pandas.DataFrame instead of a tuple of pandas.Series, making it easier to work with the result.

### Other information:
