### PR TITLE
Run QC functions with xarray

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ New features and enhancements
 * add buoy tracking QC functions to imports in quality_control.qc_multiple_check (:issue:`249`, :pull:`250`)
 * the documentation now includes example notebooks how to use ``marine_qc`` (:issue:`4`, :issue:`251`, :pull:`235`, :pull:`255`)
 * quality control functions now support pandas.DataFrames as input, allowing for a more flexible way of passing data using the `data` key-word-argument (:issue:`241`, :pull:`257`)
+* quality control functions now support both xarray.DataArrays and xarray.Datasets as input, allowing for a more flexible way of passing data using the `data` key-word-argument (:issue:`243`, :pull:`259`)
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
@@ -31,6 +32,8 @@ Breaking changes
 * sort parameter order list in buoy tracking QC functions equivalent to other QC functions, for instance ["lon", "lat", "date"] to ["lat", "lon", "date"] (:issue:`249`, :pull:`250`)
 * ``cartopy`` has been added to the dependencies (:pull:`235`)
 * when a pandas.DataFrame is provided as input to `remove_duplicates` using `data` keyword-argument, the function returns a pandas.DataFrame instead of a tuple of pandas.Series, making it easier to work with the result (:pull:`257`)
+* quality control functions do NOT raise errors when input arrays have more than 1 dimension (:pull:`259`)
+* decorator ``args_from_data`` raise TypeError if data is none of pd.DataFrame, xr.DataArray or xr.Dataset (:pull:`259`)
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -60,14 +60,33 @@ The `MarineQC` package comprises quality flags of two kids:
 Running the QC Checks
 ---------------------
 
-The QC checks can be run simply. Each one takes one or more input values, which can be a float, list, 1-d numpy array
-or Pandas DataSeries, along with zero or more parameters depending on the function.
+The QC checks can be run simply. Each one takes one or more input values, which can be a float, list, numpy array,
+a pandas DataSeries, or a xarray DataArray, along with zero or more parameters depending on the function.
 
 So, for example, one can run a hard limit check like so::
 
 
   input_values = np.array([-15.0, 0.0, 20.0, 55.0])
   result = do_hard_limit_check(input_values, [-10., 40.])
+
+The required arguments can be extracted directly from a pandas DataFrame or a xarray Dataset::
+
+  data = pd.Dataset(
+      "lat": [0.0, 45.0, 91.0, -91.0, 0.0, 0.0, None, 0.0],
+      "lon": [0.0, 125.0, 0.0, 0.0, -180.1, 360.1, 0.0, None],
+  )
+  result = do_position_check(data=data)
+
+  lat = [0.0, 45.0, 91.0, -91.0, 0.0, 0.0, None, 0.0]
+  lon = [0.0, 125.0, 0.0, 0.0, -180.1, 360.1, 0.0, None]
+  temperature = np.random.uniform(250, 300, size=(len(lat), len(lon)))
+  da = xr.DataArray(
+        temperature,
+        dims=["lat", "lon"],
+        coords={"lat": lat, "lon": lon},
+  )
+  ds = xr.Dataset(data_vars={"temp": da})
+  result = do_position_check(data=ds)
 
 Additionally, some checks use climatological averages which can be provided like the other
 inputs, or passed as a :class:`~marine_qc.Climatology` object. For example, the climatology check can be run like so::

--- a/src/marine_qc/helpers/auxiliary.py
+++ b/src/marine_qc/helpers/auxiliary.py
@@ -852,7 +852,7 @@ def args_from_data(*params: str) -> Callable[..., Any]:
                     return param in data.coords or param in data.dims
                 elif isinstance(data, xr.Dataset):
                     return param in data.data_vars or param in data.coords or param in data.dims
-                raise TypeError(f"Type of 'data' must be one of pd.DataFrame, xr.DataArray or xr.Dataset not {type(data)}.")
+                raise TypeError(f"Type of 'data' must be one of pd.DataFrame, xr.DataArray or xr.Dataset, not {type(data)}.")
 
             if "data" not in kwargs:
                 return func(*args, **kwargs)

--- a/src/marine_qc/helpers/auxiliary.py
+++ b/src/marine_qc/helpers/auxiliary.py
@@ -552,7 +552,6 @@ def inspect_arrays(*params: str, sortby: str | None = None) -> Callable[..., Any
     ------
     ValueError
         If a specified parameter is missing from the function arguments.
-        If any specified parameter is not one-dimensional.
         If the lengths of the specified arrays do not all match.
 
     Notes
@@ -598,9 +597,6 @@ def inspect_arrays(*params: str, sortby: str | None = None) -> Callable[..., Any
 
             value = arguments[param]
             arr = np.atleast_1d(arguments[param])
-
-            # if arr.ndim != 1:
-            #    raise ValueError(f"Input '{param}' must be one-dimensional.")
 
             arguments[param] = arr
             if value is not None:
@@ -821,12 +817,35 @@ def args_from_data(*params: str) -> Callable[..., Any]:
 
             Raises
             ------
+            TypeError
+                If ``data`` is none of pandas.DataFrame, xarray.DataArray or xarray.Dataset.
             ValueError
                 If both positional arguments and the ``data`` keyword
                 argument are provided.
             """
 
-            def isin(param, data):
+            def isin(param: str, data: Any) -> bool:
+                """
+                Check whether a parameter's name is in a data object.
+
+                Parameters
+                ----------
+                param : str
+                    Name of the parameter to be checked.
+
+                data : Any
+                    Any data object to be checked.
+
+                Returns
+                -------
+                bool
+                    Boolean value whether ``data`` contains ``param``.
+
+                Raises
+                ------
+                TypeError
+                    If ``data`` is none of pandas.DataFrame, xarray.DataArray or xarray.Dataset.
+                """
                 if isinstance(data, pd.DataFrame):
                     return param in data.columns
                 elif isinstance(data, xr.DataArray):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -104,16 +104,14 @@ def test_inspect_arrays(value1, value2):
     np.testing.assert_equal(result2, expected2)
 
 
-def test_inspect_arrays_raise_dimension():
-    with pytest.raises(ValueError, match="Input 'value1' must be one-dimensional."):
-        _array_function(np.ndarray(shape=(2, 2), dtype=float, order="F"), [1, 2, 3])
-
-
 def test_inspect_arrays_raise_length():
     error_msg = "Input ('value1', 'value2') must all have the same length."
     escaped_msg = re.escape(error_msg)
     with pytest.raises(ValueError, match=escaped_msg):
         _array_function([1, 2, 3, 4], [1, 2, 3])
+
+    with pytest.raises(ValueError, match=escaped_msg):
+        _array_function(np.ndarray(shape=(2, 2), dtype=float, order="F"), [1, 2, 3])
 
 
 def test_inspect_arrays_raise_parameter():

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -4,6 +4,7 @@ import re
 import numpy as np
 import pandas as pd
 import pytest
+import xarray as xr
 from pint.errors import DimensionalityError
 
 from marine_qc.helpers.auxiliary import (
@@ -119,7 +120,7 @@ def test_inspect_arrays_raise_parameter():
         _array_function2(1, 2)
 
 
-def test_args_from_data_pass():
+def test_args_from_data_pd():
     data = pd.DataFrame(
         {
             "lat": [10.0, 15.0, 20.0],
@@ -134,6 +135,36 @@ def test_args_from_data_pass():
 
     pd.testing.assert_series_equal(result[0], data["lat"])
     pd.testing.assert_series_equal(result[1], data["lon"])
+
+
+def test_args_from_data_xr():
+    lat = [10.0, 15.0, 20.0]
+    lon = [-10.0, 0.0, 10.0]
+    year = [2024, 2025, 2026]
+    temp = np.random.rand(len(year), len(lat), len(lon))
+
+    da = xr.DataArray(
+        temp,
+        dims=["year", "lat", "lon"],
+        coords={"year": year, "lat": lat, "lon": lon},
+    )
+    ds = xr.Dataset(data_vars={"temp": da})
+
+    result = _data_function(data=da)
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+
+    xr.testing.assert_equal(result[0], da.lat)
+    xr.testing.assert_equal(result[1], da.lon)
+
+    result = _data_function(data=ds)
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+
+    xr.testing.assert_equal(result[0], ds.lat)
+    xr.testing.assert_equal(result[1], ds.lon)
 
 
 def test_args_from_data_valueerror():
@@ -158,6 +189,9 @@ def test_args_from_data_typeerror():
 
     with pytest.raises(TypeError, match="missing 2 required positional arguments"):
         _data_function(data=data)
+
+    with pytest.raises(TypeError, match="Type of 'data' must be one of pd.DataFrame, xr.DataArray or xr.Dataset"):
+        _data_function(data=[2024, 2025, 2026])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_individual_report_qc.py
+++ b/tests/test_individual_report_qc.py
@@ -141,7 +141,7 @@ def test_do_position_check_untestable():
     assert do_position_check(0.0, None) == 2
 
 
-def test_do_position_check_df():
+def test_do_position_check_pd():
     data = pd.DataFrame(
         {
             "lat": [0.0, 45.0, 91.0, -91.0, 0.0, 0.0, None, 0.0],
@@ -153,6 +153,33 @@ def test_do_position_check_df():
     result = do_position_check(data=data)
 
     pd.testing.assert_series_equal(result, expected)
+
+
+def test_do_position_check_xr():
+    lat = [0.0, 45.0, 91.0, -91.0, 0.0, 0.0, None, 0.0]
+    lon = [0.0, 125.0, 0.0, 0.0, -180.1, 360.1, 0.0, None]
+    date = pd.date_range(start="2026-07-17T12:00", end="2026-07-14T12:00", freq="D")
+    temperature = np.random.uniform(250, 300, size=(len(date), len(lat), len(lon)))
+    da = xr.DataArray(
+        temperature,
+        dims=["date", "lat", "lon"],
+        coords={"date": date, "lat": lat, "lon": lon},
+    )
+    ds = xr.Dataset(data_vars={"temp": da})
+
+    expected = xr.DataArray(
+        [passed, passed, failed, failed, failed, failed, untestable, untestable],
+        dims="lat",
+        coords={"lat": lat},
+    )
+
+    result = do_position_check(data=ds)
+
+    xr.testing.assert_equal(result, expected)
+
+    result = do_position_check(data=da)
+
+    xr.testing.assert_equal(result, expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
  - This PR fixes #243 
- [x] (If applicable) Documentation has been added / updated (for bug fixes / features).
- [x] (If applicable) Tests have been added.
- [x] CHANGELOG.rst has been updated (with summary of main changes).
  - [x] Link to issue (:issue:`number`) and pull request (:pull:`number`) has been added.

### What kind of change does this PR introduce?

* Run QC functions with both xr.DataArrays and xr.Datasets.

### Does this PR introduce a breaking change?
* QC functions do NOT raise errors when input arrays have more than 1 dimension.
* decorator ``args_from_data`` raise TypeError if ``data`` is none of pd.DataFrame, xr.DataArray or xr.Dataset.
### Other information:
