### PR TITLE
Reject new updates detected with Cruft

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/Ouranosinc/cookiecutter-pypackage.git",
-  "commit": "3c1f362148b15e97a7a7d252f39f40d4175dfcb2",
+  "commit": "ca71222b12478c5123bb4f1d973ccbec53b965eb",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -35,7 +35,7 @@
         ".github/workflows/workflow-warning.yml"
       ],
       "_template": "https://github.com/Ouranosinc/cookiecutter-pypackage.git",
-      "_commit": "3c1f362148b15e97a7a7d252f39f40d4175dfcb2"
+      "_commit": "ca71222b12478c5123bb4f1d973ccbec53b965eb"
     }
   },
   "directory": null


### PR DESCRIPTION
This is an autogenerated PR. Use this to reject the changes in this repository.
[Cruft](https://cruft.github.io/cruft/) has detected updates from the Cookiecutter repository.